### PR TITLE
feat: Implement robust tests for McpConfig Service

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2,7 +2,7 @@
   "lockfileVersion": 1,
   "workspaces": {
     "": {
-      "name": "stitch-mcp",
+      "name": "@_davideast/stitch-mcp",
       "dependencies": {
         "@inquirer/prompts": "^7.2.0",
         "@modelcontextprotocol/sdk": "^1.25.2",

--- a/src/services/mcp-config/handler.test.ts
+++ b/src/services/mcp-config/handler.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'bun:test';
+import { McpConfigHandler } from './handler';
+import type { McpClient } from './spec';
+
+describe('McpConfigHandler', () => {
+  const handler = new McpConfigHandler();
+
+  const clients: McpClient[] = ['antigravity', 'vscode', 'cursor', 'claude-code', 'gemini-cli'];
+
+  const clientDisplayNames: Record<McpClient, string> = {
+    antigravity: 'Antigravity',
+    vscode: 'VSCode',
+    cursor: 'Cursor',
+    'claude-code': 'Claude Code',
+    'gemini-cli': 'Gemini CLI',
+  };
+
+  it('should generate a valid configuration for all clients', async () => {
+    for (const client of clients) {
+      const input = {
+        client,
+        projectId: 'test-project',
+        accessToken: 'test-token',
+      };
+
+      const result = await handler.generateConfig(input);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const config = JSON.parse(result.data.config);
+        expect(config.mcpServers.stitch.headers.Authorization).toBe('Bearer test-token');
+        expect(config.mcpServers.stitch.headers['X-Goog-User-Project']).toBe('test-project');
+        expect(result.data.instructions).toContain(clientDisplayNames[client]);
+      }
+    }
+  });
+
+  it('should return an error if config generation fails', async () => {
+    const originalStringify = JSON.stringify;
+    JSON.stringify = () => {
+      throw new Error('Test error');
+    };
+
+    const input = {
+      client: 'vscode' as McpClient,
+      projectId: 'test-project',
+      accessToken: 'test-token',
+    };
+
+    const result = await handler.generateConfig(input);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.code).toBe('CONFIG_GENERATION_FAILED');
+      expect(result.error.message).toBe('Test error');
+    }
+
+    JSON.stringify = originalStringify;
+  });
+});

--- a/src/services/mcp-config/spec.test.ts
+++ b/src/services/mcp-config/spec.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'bun:test';
+import { GenerateConfigInputSchema } from './spec';
+
+describe('McpConfig Service Spec', () => {
+  describe('GenerateConfigInputSchema', () => {
+    it('should validate a correct input', () => {
+      const input = {
+        client: 'vscode',
+        projectId: 'test-project',
+        accessToken: 'test-token',
+      };
+      const result = GenerateConfigInputSchema.safeParse(input);
+      expect(result.success).toBe(true);
+    });
+
+    it('should invalidate an input with an invalid client', () => {
+      const input = {
+        client: 'invalid-client',
+        projectId: 'test-project',
+        accessToken: 'test-token',
+      };
+      const result = GenerateConfigInputSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+
+    it('should invalidate an input with a missing projectId', () => {
+      const input = {
+        client: 'vscode',
+        accessToken: 'test-token',
+      };
+      const result = GenerateConfigInputSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+
+    it('should invalidate an input with a missing accessToken', () => {
+      const input = {
+        client: 'vscode',
+        projectId: 'test-project',
+      };
+      const result = GenerateConfigInputSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+
+    it('should invalidate an input with an empty projectId', () => {
+      const input = {
+        client: 'vscode',
+        projectId: '',
+        accessToken: 'test-token',
+      };
+      const result = GenerateConfigInputSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+
+    it('should invalidate an input with an empty accessToken', () => {
+      const input = {
+        client: 'vscode',
+        projectId: 'test-project',
+        accessToken: '',
+      };
+      const result = GenerateConfigInputSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
This commit introduces comprehensive contract and logic tests for the McpConfig Service, following the `typed-service-contract` pattern.

- Created `src/services/mcp-config/spec.test.ts` to validate `GenerateConfigInputSchema`, ensuring robust input validation.
- Created `src/services/mcp-config/handler.test.ts` to test the `McpConfigHandler`, verifying the generated configuration strings for all supported clients.
- Ensured all new tests pass and do not introduce any regressions.