### PR TITLE
feat: Add contract and logic tests for Project Service

### DIFF
--- a/src/services/project/handler.test.ts
+++ b/src/services/project/handler.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, mock, beforeEach } from 'bun:test';
+import { ProjectHandler } from './handler';
+import { GcloudService } from '../gcloud/spec';
+import * as wizard from '../../ui/wizard';
+import { theme } from '../../ui/theme';
+
+// Mock GcloudService
+const mockGcloudService: Pick<GcloudService, 'listProjects'> = {
+  listProjects: mock(),
+};
+
+// Mock UI wizard functions
+mock.module('../../ui/wizard', () => ({
+  promptSelect: mock(),
+  promptInput: mock(),
+  promptConfirm: mock(),
+}));
+
+describe('ProjectHandler', () => {
+  const handler = new ProjectHandler(mockGcloudService as GcloudService);
+
+  beforeEach(() => {
+    (mockGcloudService.listProjects as any).mockClear();
+    (wizard.promptSelect as any).mockClear();
+    (wizard.promptInput as any).mockClear();
+    (wizard.promptConfirm as any).mockClear();
+  });
+
+  it('should select a project from the initial list', async () => {
+    (mockGcloudService.listProjects as any).mockResolvedValue({
+      success: true,
+      data: {
+        projects: [
+          { projectId: 'p1', name: 'Project 1' },
+          { projectId: 'p2', name: 'Project 2' },
+        ],
+      },
+    });
+    (wizard.promptSelect as any).mockResolvedValue('p1');
+
+    const result = await handler.selectProject({ allowSearch: true, limit: 5 });
+
+    expect(result).toEqual({
+      success: true,
+      data: {
+        projectId: 'p1',
+        name: 'Project 1',
+      },
+    });
+    expect(mockGcloudService.listProjects).toHaveBeenCalledWith({
+      limit: 5,
+      sortBy: '~createTime',
+    });
+    expect(wizard.promptSelect).toHaveBeenCalledWith(
+      'Select a project',
+      expect.arrayContaining([
+        { name: theme.gray('🔍 Search for a project...'), value: '__SEARCH__' },
+        { name: `Project 1 ${theme.gray('(p1)')}`, value: 'p1' },
+      ])
+    );
+  });
+
+  it('should handle project search and selection', async () => {
+    (mockGcloudService.listProjects as any)
+      .mockResolvedValueOnce({
+        success: true,
+        data: {
+          projects: [{ projectId: 'p1', name: 'Recent Project' }],
+        },
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        data: {
+          projects: [{ projectId: 'search-result', name: 'Search Result' }],
+        },
+      });
+
+    (wizard.promptSelect as any)
+      .mockResolvedValueOnce('__SEARCH__')
+      .mockResolvedValueOnce('search-result');
+    (wizard.promptInput as any).mockResolvedValue('search-term');
+
+    const result = await handler.selectProject({ allowSearch: true, limit: 5 });
+
+    expect(result).toEqual({
+      success: true,
+      data: {
+        projectId: 'search-result',
+        name: 'Search Result',
+      },
+    });
+    expect(mockGcloudService.listProjects).toHaveBeenCalledTimes(2);
+    expect((mockGcloudService.listProjects as any).mock.calls[1][0]).toEqual({
+      filter: 'name:*search-term* OR projectId:*search-term*',
+      limit: 5,
+    });
+  });
+
+  it('should handle gcloud listProjects failure', async () => {
+    (mockGcloudService.listProjects as any).mockResolvedValue({
+      success: false,
+      error: { message: 'Auth error' },
+    });
+
+    const result = await handler.selectProject({ limit: 5 });
+
+    expect(result).toEqual({
+      success: false,
+      error: {
+        code: 'SEARCH_FAILED',
+        message: 'Failed to fetch projects',
+        suggestion: 'Ensure you are authenticated and have access to GCP projects',
+        recoverable: true,
+      },
+    });
+  });
+
+  it('should handle no projects found', async () => {
+    (mockGcloudService.listProjects as any).mockResolvedValue({
+      success: true,
+      data: { projects: [] },
+    });
+
+    const result = await handler.selectProject({ limit: 5 });
+
+    expect(result).toEqual({
+      success: false,
+      error: {
+        code: 'NO_PROJECTS_FOUND',
+        message: 'No projects found in your account',
+        suggestion: 'Create a project at https://console.cloud.google.com',
+        recoverable: false,
+      },
+    });
+  });
+
+  it('should handle search with no results and allow manual entry', async () => {
+    (mockGcloudService.listProjects as any)
+      .mockResolvedValueOnce({
+        success: true,
+        data: { projects: [{ projectId: 'p1', name: 'Recent' }] },
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        data: { projects: [] },
+      });
+
+    (wizard.promptSelect as any).mockResolvedValue('__SEARCH__');
+    (wizard.promptInput as any).mockResolvedValue('manual-id');
+    (wizard.promptConfirm as any).mockResolvedValue(true);
+
+    const result = await handler.selectProject({ limit: 5 });
+
+    expect(result).toEqual({
+      success: true,
+      data: {
+        projectId: 'manual-id',
+        name: 'manual-id',
+      },
+    });
+  });
+});

--- a/src/services/project/spec.test.ts
+++ b/src/services/project/spec.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'bun:test';
+import {
+  SelectProjectInputSchema,
+  ProjectSelectionSuccess,
+  ProjectSelectionFailure,
+} from './spec.js';
+
+describe('Project Service Contracts', () => {
+  describe('SelectProjectInputSchema', () => {
+    it('should validate a valid input', () => {
+      const input = {
+        allowSearch: true,
+        limit: 10,
+      };
+      const result = SelectProjectInputSchema.safeParse(input);
+      expect(result.success).toBe(true);
+    });
+
+    it('should use default values', () => {
+      const input = {};
+      const result = SelectProjectInputSchema.safeParse(input);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual({
+          allowSearch: true,
+          limit: 5,
+        });
+      }
+    });
+
+    it('should invalidate an invalid input', () => {
+      const input = {
+        allowSearch: 'true',
+        limit: '10',
+      };
+      const result = SelectProjectInputSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('ProjectSelectionResult', () => {
+    it('should validate a success result', () => {
+      const result = {
+        success: true,
+        data: {
+          projectId: 'my-project',
+          name: 'My Project',
+        },
+      };
+      const validation = ProjectSelectionSuccess.safeParse(result);
+      expect(validation.success).toBe(true);
+    });
+
+    it('should validate a failure result', () => {
+      const result = {
+        success: false,
+        error: {
+          code: 'NO_PROJECTS_FOUND',
+          message: 'No projects found',
+          recoverable: false,
+        },
+      };
+      const validation = ProjectSelectionFailure.safeParse(result);
+      expect(validation.success).toBe(true);
+    });
+
+    it('should invalidate an invalid success result', () => {
+      const result = {
+        success: true,
+        data: {
+          projectId: 123,
+        },
+      };
+      const validation = ProjectSelectionSuccess.safeParse(result);
+      expect(validation.success).toBe(false);
+    });
+
+    it('should invalidate an invalid failure result', () => {
+      const result = {
+        success: false,
+        error: {
+          code: 'INVALID_CODE',
+          message: 'An error occurred',
+        },
+      };
+      const validation = ProjectSelectionFailure.safeParse(result);
+      expect(validation.success).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
This commit introduces robust contract and logic tests for the Project Service in 'src/services/project' using 'bun:test'.

- Creates 'src/services/project/spec.test.ts' to validate the service's input and output schemas.
- Creates 'src/services/project/handler.test.ts' to test the service's business logic, with mocked dependencies for 'GcloudHandler' and UI components.
- Follows the 'typed-service-contract' pattern.
- Verifies the implementation with 'bun test'.