### PR TITLE
feat: Add tests for Proxy Command

### DIFF
--- a/src/commands/proxy/handler.test.ts
+++ b/src/commands/proxy/handler.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, mock, beforeEach } from 'bun:test';
+import { ProxyCommandHandler } from './handler.js';
+import { ProxyHandler } from '../../services/proxy/handler.js';
+import type { StartProxyInput } from '../../services/proxy/spec.js';
+
+const mockProxyService = {
+  start: mock(),
+};
+
+mock.module('../../services/proxy/handler.js', () => {
+  return {
+    ProxyHandler: class {
+      start = mockProxyService.start;
+    },
+  };
+});
+
+describe('ProxyCommandHandler', () => {
+  beforeEach(() => {
+    (mockProxyService.start as any).mockClear();
+  });
+
+  it('should call the proxy service with the correct arguments for sse transport', async () => {
+    const commandHandler = new ProxyCommandHandler();
+    const input: StartProxyInput = {
+      transport: 'sse',
+      port: 8080,
+      debug: true,
+    };
+
+    mockProxyService.start.mockResolvedValue({ success: true, data: { status: 'stopped' } });
+
+    await commandHandler.execute(input);
+
+    expect(mockProxyService.start).toHaveBeenCalledWith(input);
+  });
+
+  it('should call the proxy service with the correct arguments for stdio transport', async () => {
+    const commandHandler = new ProxyCommandHandler();
+    const input: StartProxyInput = {
+      transport: 'stdio',
+      debug: false,
+    };
+
+    mockProxyService.start.mockResolvedValue({ success: true, data: { status: 'stopped' } });
+
+    await commandHandler.execute(input);
+
+    expect(mockProxyService.start).toHaveBeenCalledWith(input);
+  });
+
+  it('should handle undefined values for optional arguments', async () => {
+    const commandHandler = new ProxyCommandHandler();
+    const input: StartProxyInput = {
+      transport: 'stdio',
+    };
+
+    mockProxyService.start.mockResolvedValue({ success: true, data: { status: 'stopped' } });
+
+    await commandHandler.execute(input);
+
+    expect(mockProxyService.start).toHaveBeenCalledWith(input);
+  });
+});


### PR DESCRIPTION
This commit introduces unit tests for the `ProxyCommandHandler` in `src/commands/proxy/handler.test.ts`.

The tests use `bun:test` to mock the `ProxyService` and verify that the command handler correctly parses arguments (port, transport, debug) and calls the service with the expected input. This ensures the command handler is working as expected and provides a foundation for future development.