### PR TITLE
feat: add Codex CLI client to init

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,26 +79,6 @@ Setup Complete! ✔
 
 Copy this config into your MCP client settings and you're ready to use the Stitch MCP server.
 
-**Codex CLI (manual config):**
-
-Codex isn't a selectable client yet, but it works with a manual MCP server entry. Add this to `~/.codex/config.toml`:
-
-```toml
-[mcp_servers.stitch]
-command = "npx"
-args = ["-y", "@_davideast/stitch-mcp", "proxy"]
-enabled = false
-
-[mcp_servers.stitch.env]
-STITCH_PROJECT_ID = "your-project-id"
-```
-
-Enable it per run:
-
-```bash
-codex exec -c 'mcp_servers.stitch.enabled=true' "Use the stitch MCP server"
-```
-
 ## Verify Your Setup
 
 ```bash

--- a/src/commands/init/handler.ts
+++ b/src/commands/init/handler.ts
@@ -208,7 +208,16 @@ export class InitHandler implements InitCommand {
       this.updateStep(STEPS.CONNECTION, 'IN_PROGRESS');
 
       let transport: 'http' | 'stdio';
-      if (input.transport) {
+      if (mcpClient === 'codex') {
+        if (input.transport) {
+          const requestedTransport = this.resolveTransport(input.transport);
+          if (requestedTransport !== 'stdio') {
+            console.log(theme.yellow('  ⚠ Codex CLI uses the proxy (stdio) transport. Ignoring --transport http.'));
+          }
+        }
+        transport = 'stdio';
+        this.updateStep(STEPS.CONNECTION, 'SKIPPED', 'Proxy', 'Codex uses proxy transport');
+      } else if (input.transport) {
         transport = this.resolveTransport(input.transport);
         this.updateStep(STEPS.CONNECTION, 'SKIPPED', transport === 'http' ? 'Direct' : 'Proxy', 'Set via --transport flag');
       } else {
@@ -496,13 +505,14 @@ export class InitHandler implements InitCommand {
       'vscode': 'vscode', 'vsc': 'vscode',
       'cursor': 'cursor', 'cur': 'cursor',
       'claude-code': 'claude-code', 'cc': 'claude-code',
-      'gemini-cli': 'gemini-cli', 'gcli': 'gemini-cli'
+      'gemini-cli': 'gemini-cli', 'gcli': 'gemini-cli',
+      'codex': 'codex', 'cdx': 'codex'
     };
 
     const normalized = input.trim().toLowerCase();
     const client = map[normalized];
     if (!client) {
-      throw new Error(`Invalid client '${input}'. Supported: antigravity (agy), vscode (vsc), cursor (cur), claude-code (cc), gemini-cli (gcli)`);
+      throw new Error(`Invalid client '${input}'. Supported: antigravity (agy), vscode (vsc), cursor (cur), claude-code (cc), gemini-cli (gcli), codex (cdx)`);
     }
     return client;
   }

--- a/src/services/mcp-config/handler.test.ts
+++ b/src/services/mcp-config/handler.test.ts
@@ -5,7 +5,7 @@ import type { McpClient } from './spec';
 describe('McpConfigHandler', () => {
   const handler = new McpConfigHandler();
 
-  const clients: McpClient[] = ['antigravity', 'vscode', 'cursor', 'claude-code', 'gemini-cli'];
+  const clients: McpClient[] = ['antigravity', 'vscode', 'cursor', 'claude-code', 'gemini-cli', 'codex'];
 
   const clientDisplayNames: Record<McpClient, string> = {
     antigravity: 'Antigravity',
@@ -13,6 +13,7 @@ describe('McpConfigHandler', () => {
     cursor: 'Cursor',
     'claude-code': 'Claude Code',
     'gemini-cli': 'Gemini CLI',
+    codex: 'Codex CLI',
   };
 
   it('should generate Cursor configuration with correct format', async () => {
@@ -124,6 +125,26 @@ describe('McpConfigHandler', () => {
     }
   });
 
+  it('should generate Codex CLI config instructions instead of JSON config', async () => {
+    const input = {
+      client: 'codex' as const,
+      projectId: 'test-project',
+      accessToken: 'test-token',
+      transport: 'stdio' as const,
+    };
+
+    const result = await handler.generateConfig(input);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.config).toBe('');
+      expect(result.data.instructions).toContain('Codex CLI');
+      expect(result.data.instructions).toContain('~/.codex/config.toml');
+      expect(result.data.instructions).toContain('STITCH_PROJECT_ID = "test-project"');
+      expect(result.data.instructions).toContain('codex exec -c');
+    }
+  });
+
   it('should generate Claude Code stdio command for proxy transport', async () => {
     const input = {
       client: 'claude-code' as const,
@@ -147,7 +168,7 @@ describe('McpConfigHandler', () => {
 
   it('should generate a valid STDIO configuration for JSON-based clients', async () => {
     // Skip command-based clients that don't generate JSON configs
-    const jsonBasedClients = clients.filter(c => c !== 'claude-code' && c !== 'gemini-cli');
+    const jsonBasedClients = clients.filter(c => c !== 'claude-code' && c !== 'gemini-cli' && c !== 'codex');
 
     for (const client of jsonBasedClients) {
       const input = {

--- a/src/services/mcp-config/spec.ts
+++ b/src/services/mcp-config/spec.ts
@@ -5,11 +5,11 @@ import { z } from 'zod';
 // ============================================================================
 // ============================================================================
 
-export type McpClient = 'antigravity' | 'vscode' | 'cursor' | 'claude-code' | 'gemini-cli';
+export type McpClient = 'antigravity' | 'vscode' | 'cursor' | 'claude-code' | 'gemini-cli' | 'codex';
 export type TransportType = 'http' | 'stdio';
 
 export const GenerateConfigInputSchema = z.object({
-  client: z.enum(['antigravity', 'vscode', 'cursor', 'claude-code', 'gemini-cli']),
+  client: z.enum(['antigravity', 'vscode', 'cursor', 'claude-code', 'gemini-cli', 'codex']),
   projectId: z.string().min(1),
   accessToken: z.string().min(1),
   transport: z.enum(['http', 'stdio']).default('http'),

--- a/src/ui/wizard.ts
+++ b/src/ui/wizard.ts
@@ -1,6 +1,6 @@
 import { select, input, confirm } from '@inquirer/prompts';
 
-export type McpClient = 'antigravity' | 'vscode' | 'cursor' | 'claude-code' | 'gemini-cli';
+export type McpClient = 'antigravity' | 'vscode' | 'cursor' | 'claude-code' | 'gemini-cli' | 'codex';
 
 /**
  * Prompt user to select their MCP client
@@ -14,6 +14,7 @@ export async function promptMcpClient(): Promise<McpClient> {
       { name: 'Cursor', value: 'cursor' as McpClient },
       { name: 'Claude Code', value: 'claude-code' as McpClient },
       { name: 'Gemini CLI', value: 'gemini-cli' as McpClient },
+      { name: 'Codex CLI', value: 'codex' as McpClient },
     ],
   });
 }


### PR DESCRIPTION
## Summary
- add Codex CLI as a selectable init client
- render Codex-specific setup instructions and proxy transport handling

## Testing
- not run (bun not installed)