### PR TITLE
Add OpenCode MCP client support

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ npx @_davideast/stitch-mcp init [options]
 **Options:**
 - `--local` - Install gcloud locally to project instead of user home
 - `-y, --yes` - Auto-approve verification prompts (skips "Check your current setup status?")
-- `-c, --client <client>` - Specify MCP client (antigravity, vscode, cursor, claude-code, gemini-cli)
+- `-c, --client <client>` - Specify MCP client (antigravity, vscode, cursor, claude-code, gemini-cli, opencode)
 - `-t, --transport <type>` - Transport type (http or stdio)
 
 **What happens:**

--- a/src/commands/init/handler.ts
+++ b/src/commands/init/handler.ts
@@ -506,13 +506,14 @@ export class InitHandler implements InitCommand {
       'cursor': 'cursor', 'cur': 'cursor',
       'claude-code': 'claude-code', 'cc': 'claude-code',
       'gemini-cli': 'gemini-cli', 'gcli': 'gemini-cli',
-      'codex': 'codex', 'cdx': 'codex'
+      'codex': 'codex', 'cdx': 'codex',
+      'opencode': 'opencode', 'opc': 'opencode'
     };
 
     const normalized = input.trim().toLowerCase();
     const client = map[normalized];
     if (!client) {
-      throw new Error(`Invalid client '${input}'. Supported: antigravity (agy), vscode (vsc), cursor (cur), claude-code (cc), gemini-cli (gcli), codex (cdx)`);
+      throw new Error(`Invalid client '${input}'. Supported: antigravity (agy), vscode (vsc), cursor (cur), claude-code (cc), gemini-cli (gcli), codex (cdx), opencode (opc)`);
     }
     return client;
   }

--- a/src/services/mcp-config/handler.test.ts
+++ b/src/services/mcp-config/handler.test.ts
@@ -5,7 +5,7 @@ import type { McpClient } from './spec';
 describe('McpConfigHandler', () => {
   const handler = new McpConfigHandler();
 
-  const clients: McpClient[] = ['antigravity', 'vscode', 'cursor', 'claude-code', 'gemini-cli', 'codex'];
+  const clients: McpClient[] = ['antigravity', 'vscode', 'cursor', 'claude-code', 'gemini-cli', 'codex', 'opencode'];
 
   const clientDisplayNames: Record<McpClient, string> = {
     antigravity: 'Antigravity',
@@ -14,6 +14,7 @@ describe('McpConfigHandler', () => {
     'claude-code': 'Claude Code',
     'gemini-cli': 'Gemini CLI',
     codex: 'Codex CLI',
+    opencode: 'OpenCode',
   };
 
   it('should generate Cursor configuration with correct format', async () => {
@@ -145,6 +146,54 @@ describe('McpConfigHandler', () => {
     }
   });
 
+  it('should generate OpenCode HTTP configuration with remote type', async () => {
+    const input = {
+      client: 'opencode' as const,
+      projectId: 'test-project',
+      accessToken: 'test-token',
+      transport: 'http' as const,
+    };
+
+    const result = await handler.generateConfig(input);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const config = JSON.parse(result.data.config);
+      expect(config.$schema).toBe('https://opencode.ai/config.json');
+      expect(config.mcp).toBeDefined();
+      expect(config.mcp.stitch.type).toBe('remote');
+      expect(config.mcp.stitch.url).toBe('https://stitch.googleapis.com/mcp');
+      expect(config.mcp.stitch.headers.Authorization).toBe('Bearer $STITCH_ACCESS_TOKEN');
+      expect(config.mcp.stitch.headers['X-Goog-User-Project']).toBe('$GOOGLE_CLOUD_PROJECT');
+      expect(result.data.instructions).toContain('OpenCode');
+      expect(result.data.instructions).toContain('opencode.json');
+      expect(result.data.instructions).toContain('OAuth');
+    }
+  });
+
+  it('should generate OpenCode STDIO configuration with local type', async () => {
+    const input = {
+      client: 'opencode' as const,
+      projectId: 'test-project',
+      accessToken: 'test-token',
+      transport: 'stdio' as const,
+    };
+
+    const result = await handler.generateConfig(input);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const config = JSON.parse(result.data.config);
+      expect(config.$schema).toBe('https://opencode.ai/config.json');
+      expect(config.mcp).toBeDefined();
+      expect(config.mcp.stitch.type).toBe('local');
+      expect(config.mcp.stitch.command).toEqual(['npx', '@_davideast/stitch-mcp', 'proxy']);
+      expect(config.mcp.stitch.environment.STITCH_PROJECT_ID).toBe('test-project');
+      expect(result.data.instructions).toContain('OpenCode');
+      expect(result.data.instructions).toContain('proxy server');
+    }
+  });
+
   it('should generate Claude Code stdio command for proxy transport', async () => {
     const input = {
       client: 'claude-code' as const,
@@ -167,8 +216,8 @@ describe('McpConfigHandler', () => {
   });
 
   it('should generate a valid STDIO configuration for JSON-based clients', async () => {
-    // Skip command-based clients that don't generate JSON configs
-    const jsonBasedClients = clients.filter(c => c !== 'claude-code' && c !== 'gemini-cli' && c !== 'codex');
+    // Skip command-based clients that don't generate JSON configs and opencode which has different structure
+    const jsonBasedClients = clients.filter(c => c !== 'claude-code' && c !== 'gemini-cli' && c !== 'codex' && c !== 'opencode');
 
     for (const client of jsonBasedClients) {
       const input = {

--- a/src/services/mcp-config/handler.ts
+++ b/src/services/mcp-config/handler.ts
@@ -50,6 +50,8 @@ export class McpConfigHandler implements McpConfigService {
         return this.generateGeminiCliConfig();
       case 'codex':
         return null;
+      case 'opencode':
+        return this.generateOpencodeConfig();
     }
   }
 
@@ -107,10 +109,41 @@ export class McpConfigHandler implements McpConfigService {
     return null;
   }
 
+  private generateOpencodeConfig() {
+    return {
+      "$schema": "https://opencode.ai/config.json",
+      mcp: {
+        stitch: {
+          type: "remote",
+          url: "https://stitch.googleapis.com/mcp",
+          headers: {
+            Authorization: "Bearer $STITCH_ACCESS_TOKEN",
+            "X-Goog-User-Project": "$GOOGLE_CLOUD_PROJECT",
+          },
+        },
+      },
+    };
+  }
+
   private generateStdioConfig(input: GenerateConfigInput) {
     // Command-based clients use CLI commands, not JSON config
     if (input.client === 'claude-code' || input.client === 'gemini-cli' || input.client === 'codex') {
       return null;
+    }
+
+    if (input.client === 'opencode') {
+      return {
+        "$schema": "https://opencode.ai/config.json",
+        mcp: {
+          stitch: {
+            type: "local",
+            command: ["npx", "@_davideast/stitch-mcp", "proxy"],
+            environment: {
+              STITCH_PROJECT_ID: input.projectId,
+            },
+          },
+        },
+      };
     }
 
     return {
@@ -231,6 +264,20 @@ export class McpConfigHandler implements McpConfigService {
           `1. Enable per run:\n` +
           `   ${theme.blue("codex exec -c 'mcp_servers.stitch.enabled=true' \"Use the stitch MCP server\"")}\n` +
           `2. Or set ${theme.blue('enabled = true')} in the config to always enable it.\n`
+        );
+      }
+
+      case 'opencode': {
+        const fileName = transport === 'http' ? 'opencode.json' : 'opencode.json';
+        return (
+          baseInstructions +
+          transportNote +
+          `\n${theme.green('Setup OpenCode:')}\n\n` +
+          `1. Add the above configuration to ${theme.blue(fileName)} in your project root\n` +
+          `2. If using HTTP transport, OpenCode will automatically handle OAuth when you first use the MCP server\n` +
+          `3. If using STDIO transport, make sure the proxy server is running with:\n` +
+          `   ${theme.blue('npx @_davideast/stitch-mcp proxy')}\n\n` +
+          `${theme.gray('Note:')} You can now use Stitch tools by adding "use the stitch tool" to your prompts.\n`
         );
       }
 

--- a/src/services/mcp-config/spec.test.ts
+++ b/src/services/mcp-config/spec.test.ts
@@ -13,6 +13,16 @@ describe('McpConfig Service Spec', () => {
       expect(result.success).toBe(true);
     });
 
+    it('should validate opencode as a valid client', () => {
+      const input = {
+        client: 'opencode',
+        projectId: 'test-project',
+        accessToken: 'test-token',
+      };
+      const result = GenerateConfigInputSchema.safeParse(input);
+      expect(result.success).toBe(true);
+    });
+
     it('should invalidate an input with an invalid client', () => {
       const input = {
         client: 'invalid-client',

--- a/src/services/mcp-config/spec.ts
+++ b/src/services/mcp-config/spec.ts
@@ -5,11 +5,11 @@ import { z } from 'zod';
 // ============================================================================
 // ============================================================================
 
-export type McpClient = 'antigravity' | 'vscode' | 'cursor' | 'claude-code' | 'gemini-cli' | 'codex';
+export type McpClient = 'antigravity' | 'vscode' | 'cursor' | 'claude-code' | 'gemini-cli' | 'codex' | 'opencode';
 export type TransportType = 'http' | 'stdio';
 
 export const GenerateConfigInputSchema = z.object({
-  client: z.enum(['antigravity', 'vscode', 'cursor', 'claude-code', 'gemini-cli', 'codex']),
+  client: z.enum(['antigravity', 'vscode', 'cursor', 'claude-code', 'gemini-cli', 'codex', 'opencode']),
   projectId: z.string().min(1),
   accessToken: z.string().min(1),
   transport: z.enum(['http', 'stdio']).default('http'),

--- a/src/ui/wizard.ts
+++ b/src/ui/wizard.ts
@@ -1,6 +1,6 @@
 import { select, input, confirm } from '@inquirer/prompts';
 
-export type McpClient = 'antigravity' | 'vscode' | 'cursor' | 'claude-code' | 'gemini-cli' | 'codex';
+export type McpClient = 'antigravity' | 'vscode' | 'cursor' | 'claude-code' | 'gemini-cli' | 'codex' | 'opencode';
 
 /**
  * Prompt user to select their MCP client
@@ -15,6 +15,7 @@ export async function promptMcpClient(): Promise<McpClient> {
       { name: 'Claude Code', value: 'claude-code' as McpClient },
       { name: 'Gemini CLI', value: 'gemini-cli' as McpClient },
       { name: 'Codex CLI', value: 'codex' as McpClient },
+      { name: 'OpenCode', value: 'opencode' as McpClient },
     ],
   });
 }


### PR DESCRIPTION
Adds OpenCode as a new MCP client option alongside existing clients (antigravity, vscode, cursor, claude-code, gemini-cli, codex).                                       
                                                                                                                                                                              
## Changes                                                                                                                                                                  

- Type definitions: Updated McpClient type and Zod schema validation
- UI integration: Added "OpenCode" to client selection prompt
- Client resolution: Added opencode and opc alias support with proper error handling
- Configuration generation: Implemented both HTTP (remote) and STDIO (local) transport configs following OpenCode's schema
- Documentation: Updated README and setup instructions                                                                                                                   
- Tests: Added comprehensive test coverage for both transport types                                                                                                                                                                                                                                                                                    


## Configuration formats                                                                                                                                                                                                                                                                                                                                  

**HTTP transport** generates remote server config with OAuth headers:         

```sh
{
  $schema: https://opencode.ai/config.json,
  mcp: {
    stitch: {
      type: remote,
      url: https://stitch.googleapis.com/mcp,
      headers: {
        Authorization: Bearer $STITCH_ACCESS_TOKEN,
        X-Goog-User-Project: $GOOGLE_CLOUD_PROJECT
      }
    }
  }
}
```                                                                                                                                                                        
                                                                                                                                                                              
**STDIO transport** generates local server config with proxy command:                                                                                                        
```sh
{
  $schema: https://opencode.ai/config.json,
   mcp: {
   stitch: {
     type: local,
     command: [npx, @_davideast/stitch-mcp, proxy],
     environment: {
       STITCH_PROJECT_ID: <project-id>
      }
    }
  }
}
```
                                                                                                                                                                              
### Usage                                                                                                                                                                    
                                                                                                                                                                              
```sh
npx @_davideast/stitch-mcp init --client opencode
```

### or using alias                                                                                                                                                         

```sh
npx @_davideast/stitch-mcp init --client opc 
```
