### PR TITLE
doc: quick start for existing gcloud users

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,46 @@ Setup Complete! ✔
 
 Copy this config into your MCP client settings and you're ready to use the Stitch MCP server.
 
+## Quick Start (Existing gcloud Users)
+
+If you already have `gcloud` configured, skip `init` and use the proxy directly.
+
+**Prerequisites:**
+```bash
+# 1. Application Default Credentials
+gcloud auth application-default login
+
+# 2. Set project (if not already set)
+gcloud config set project <PROJECT_ID>
+
+# 3. Enable Stitch API (requires beta component)
+gcloud components install beta
+gcloud beta services mcp enable stitch.googleapis.com --project=<PROJECT_ID>
+```
+
+**MCP Configuration:**
+```json
+{
+  "mcpServers": {
+    "stitch": {
+      "command": "npx",
+      "args": ["@_davideast/stitch-mcp", "proxy"],
+      "env": {
+        "STITCH_USE_SYSTEM_GCLOUD": "1"
+      }
+    }
+  }
+}
+```
+
+**Environment Variables:**
+| Variable | Description |
+|----------|-------------|
+| `STITCH_USE_SYSTEM_GCLOUD` | Use system gcloud config instead of isolated config |
+| `STITCH_PROJECT_ID` | Override project ID |
+| `GOOGLE_CLOUD_PROJECT` | Alternative project ID variable |
+| `STITCH_HOST` | Custom Stitch API endpoint |
+
 ## Verify Your Setup
 
 ```bash


### PR DESCRIPTION
## Summary

Add documentation for users who already have gcloud configured and want to use the proxy directly.

## Motivation

I successfully used Stitch MCP in Gemini CLI by following the setup at https://github.com/gemini-cli-extensions/stitch. However, when I wanted to use Stitch MCP in other MCP clients like VSCode or Cursor, I needed a local proxy to handle authentication.

The current documentation focuses on the guided `init` flow, but doesn't explain how users with an existing gcloud setup can skip `init` and use the proxy directly. This PR adds a "Quick Start (Existing gcloud Users)" section that documents:

- The prerequisites (ADC login, project setup, Stitch API enablement)
- The MCP configuration with `STITCH_USE_SYSTEM_GCLOUD` environment variable
- Other useful environment variables

## Changes

- Added new section "Quick Start (Existing gcloud Users)" to README.md
- Documented environment variables: `STITCH_USE_SYSTEM_GCLOUD`, `STITCH_PROJECT_ID`, `GOOGLE_CLOUD_PROJECT`, `STITCH_HOST`
