### PR TITLE
fix(windows): avoid spawn EINVAL for gcloud.cmd

### DIFF
--- a/src/platform/shell.ts
+++ b/src/platform/shell.ts
@@ -24,7 +24,8 @@ export async function execCommand(command: string[], options?: { cwd?: string; e
       cwd: options?.cwd || process.cwd(),
       env: { ...process.env, ...(options?.env || {}) },
       stdio: 'pipe',
-      timeout: options?.timeout
+      timeout: options?.timeout,
+      shell: process.platform === 'win32'
     };
 
     const child = spawn(cmd, args, spawnOptions) as ChildProcess;
@@ -82,7 +83,8 @@ export async function execCommandStreaming(
     const spawnOptions: SpawnOptions = {
       cwd: options?.cwd || process.cwd(),
       env: { ...process.env, ...(options?.env || {}) },
-      stdio: 'pipe'
+      stdio: 'pipe',
+      shell: process.platform === 'win32'
     };
 
     const child = spawn(cmd, args, spawnOptions) as ChildProcess;


### PR DESCRIPTION
Fixes #36.

## Problem
On Windows, `gcloud` resolves to `gcloud.cmd`. With newer Node versions (confirmed on Node v22.x and v24.x), spawning `.cmd/.bat` via `child_process.spawn()` without `shell: true` can throw `spawn EINVAL`.

This breaks `stitch-mcp doctor` and `stitch-mcp proxy` when fetching tokens (e.g. `gcloud auth print-access-token`).

## Change
Add `shell: process.platform === win32` to the spawn options in `execCommand()` (and `execCommandStreaming()` for consistency).

## Notes
- I didn’t run the bun test/build locally in this environment.
- Verified the same change fixes `doctor --verbose` and token fetch in the published package on Windows + Node v22.17.0.