### PR TITLE
feat: add Authentication Mode selection (API Key vs OAuth) to init command

### DIFF
--- a/src/commands/init/handler.test.ts
+++ b/src/commands/init/handler.test.ts
@@ -6,6 +6,9 @@ mock.module('../../ui/wizard.js', () => ({
   promptMcpClient: mock(() => Promise.resolve('antigravity')),
   promptConfirm: mock(() => Promise.resolve(true)),
   promptTransportType: mock(() => Promise.resolve('http')),
+  promptAuthMode: mock(() => Promise.resolve('oauth')),
+  promptApiKeyStorage: mock(() => Promise.resolve('skip')),
+  promptApiKey: mock(() => Promise.resolve('test-key')),
 }));
 
 const mockSpinner: Record<string, unknown> = {

--- a/src/services/mcp-config/handler_apikey.test.ts
+++ b/src/services/mcp-config/handler_apikey.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'bun:test';
+import { McpConfigHandler } from './handler';
+
+describe('McpConfigHandler (API Key)', () => {
+  const handler = new McpConfigHandler();
+
+  it('should generate Cursor configuration with API key', async () => {
+    const input = {
+      client: 'cursor' as const,
+      projectId: 'test-project',
+      accessToken: 'ignored',
+      transport: 'http' as const,
+      apiKey: 'test-api-key',
+    };
+
+    const result = await handler.generateConfig(input);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const config = JSON.parse(result.data.config);
+      expect(config.mcpServers.stitch.headers['X-Goog-Api-Key']).toBe('test-api-key');
+      expect(config.mcpServers.stitch.headers.Authorization).toBeUndefined();
+      expect(config.mcpServers.stitch.headers['X-Goog-User-Project']).toBeUndefined();
+    }
+  });
+
+  it('should generate VSCode configuration with API key', async () => {
+    const input = {
+      client: 'vscode' as const,
+      projectId: 'test-project',
+      accessToken: 'ignored',
+      transport: 'http' as const,
+      apiKey: 'test-api-key',
+    };
+
+    const result = await handler.generateConfig(input);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const config = JSON.parse(result.data.config);
+      // VSCode with API key does NOT have inputs
+      expect(config.inputs).toBeUndefined();
+      expect(config.servers.stitch.headers['X-Goog-Api-Key']).toBe('test-api-key');
+      expect(config.servers.stitch.headers.Authorization).toBeUndefined();
+    }
+  });
+
+  it('should generate Claude Code instructions with API key', async () => {
+    const input = {
+      client: 'claude-code' as const,
+      projectId: 'test-project',
+      accessToken: 'ignored',
+      transport: 'http' as const,
+      apiKey: 'test-api-key',
+    };
+
+    const result = await handler.generateConfig(input);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.instructions).toContain('--header "X-Goog-Api-Key: test-api-key"');
+      expect(result.data.instructions).not.toContain('Authorization');
+    }
+  });
+});

--- a/src/services/mcp-config/spec.ts
+++ b/src/services/mcp-config/spec.ts
@@ -11,8 +11,13 @@ export type TransportType = 'http' | 'stdio';
 export const GenerateConfigInputSchema = z.object({
   client: z.enum(['antigravity', 'vscode', 'cursor', 'claude-code', 'gemini-cli', 'codex', 'opencode']),
   projectId: z.string().min(1),
-  accessToken: z.string().min(1),
+  accessToken: z.string().optional(),
   transport: z.enum(['http', 'stdio']).default('http'),
+  authMode: z.enum(['oauth', 'apiKey']).optional(),
+  apiKey: z.string().optional(),
+}).refine(data => data.accessToken || data.apiKey, {
+  message: "Either accessToken or apiKey must be provided",
+  path: ["accessToken"],
 });
 export type GenerateConfigInput = z.infer<typeof GenerateConfigInputSchema>;
 

--- a/src/ui/wizard.ts
+++ b/src/ui/wizard.ts
@@ -1,4 +1,4 @@
-import { select, input, confirm } from '@inquirer/prompts';
+import { select, input, confirm, password } from '@inquirer/prompts';
 
 export type McpClient = 'antigravity' | 'vscode' | 'cursor' | 'claude-code' | 'gemini-cli' | 'codex' | 'opencode';
 
@@ -17,6 +17,63 @@ export async function promptMcpClient(): Promise<McpClient> {
       { name: 'Codex CLI', value: 'codex' as McpClient },
       { name: 'OpenCode', value: 'opencode' as McpClient },
     ],
+  });
+}
+
+/**
+ * Prompt user to select Authentication Mode
+ */
+export async function promptAuthMode(): Promise<'apiKey' | 'oauth'> {
+  return await select({
+    message: 'Select Authentication Mode:',
+    choices: [
+      {
+        name: 'API Key',
+        value: 'apiKey' as const,
+        description: 'Persistent keys generated in the Stitch Settings page.',
+      },
+      {
+        name: 'OAuth',
+        value: 'oauth' as const,
+        description: 'A browser-based authentication flow required by specific AI clients that do not support manual key entry, or for environments where storing persistent secrets on disk is restricted.',
+      },
+    ],
+  });
+}
+
+/**
+ * Prompt user to select API Key storage
+ */
+export async function promptApiKeyStorage(): Promise<'.env' | 'config' | 'skip'> {
+  return await select({
+    message: 'Where would you like to store your API Key?',
+    choices: [
+      {
+        name: '.env file',
+        value: '.env' as const,
+        description: 'Use the current working directory. Append if existing, create if not.',
+      },
+      {
+        name: 'MCP config',
+        value: 'config' as const,
+        description: 'Add it to the final MCP config to copy and paste.',
+      },
+      {
+        name: 'Skip',
+        value: 'skip' as const,
+        description: 'Use a placeholder in the final config.',
+      },
+    ],
+  });
+}
+
+/**
+ * Prompt user to enter API Key
+ */
+export async function promptApiKey(): Promise<string> {
+  return await password({
+    message: 'Enter your Stitch API Key:',
+    mask: '*',
   });
 }
 


### PR DESCRIPTION
- Added `promptAuthMode`, `promptApiKeyStorage`, `promptApiKey` to wizard.
- Updated `InitHandler` to ask for Auth Mode early.
- If API Key is selected, skip OAuth/Gcloud/Project steps and generate config directly.
- Updated `McpConfigHandler` to support `apiKey` input and generate correct headers (`X-Goog-Api-Key`).
- Updated schema to make `accessToken` optional but refine validation.
- Updated `setupGeminiExtension` to support API Key.
- Updated tests.