### PR TITLE
fix: update view command to use MCP tool calls

### DIFF
--- a/src/services/mcp-client/client.ts
+++ b/src/services/mcp-client/client.ts
@@ -1,6 +1,5 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import { ReadResourceResultSchema, ListResourcesResultSchema } from "@modelcontextprotocol/sdk/types.js";
 import { execSync } from "child_process";
 import { StitchConfigSchema, type StitchConfig, type StitchMCPClientSpec } from './spec.js';
 
@@ -184,24 +183,6 @@ export class StitchMCPClient implements StitchMCPClientSpec {
     }
 
     return anyResult as T;
-  }
-
-  async readResource(uri: string): Promise<any> {
-    if (!this.isConnected) await this.connect();
-    const result = await this.client.request(
-      { method: "resources/read", params: { uri } },
-      ReadResourceResultSchema
-    );
-    return result;
-  }
-
-  async listResources(): Promise<any> {
-    if (!this.isConnected) await this.connect();
-    const result = await this.client.request(
-      { method: "resources/list" },
-      ListResourcesResultSchema
-    );
-    return result;
   }
 
   async getCapabilities() {

--- a/src/services/mcp-client/spec.ts
+++ b/src/services/mcp-client/spec.ts
@@ -13,8 +13,6 @@ export type StitchConfig = z.infer<typeof StitchConfigSchema>;
 export interface StitchMCPClientSpec {
   connect(): Promise<void>;
   callTool<T>(name: string, args: Record<string, any>): Promise<T>;
-  readResource(uri: string): Promise<any>;
-  listResources(): Promise<any>;
   getCapabilities(): Promise<any>;
   close(): Promise<void>;
 }


### PR DESCRIPTION
The `view` command was failing because the Stitch server does not support MCP resource methods. This PR updates the command to use `callTool` instead, mapping user inputs to the appropriate tool calls (`list_projects`, `get_project`, `get_screen`). It also cleans up the client by removing the now unused `readResource` and `listResources` methods and updates the test suite.

---
*PR created automatically by Jules for task [13089662979736062865](https://jules.google.com/task/13089662979736062865) started by @davideast*