### PR TITLE
fix(mcp-client): skip OAuth token validation when API key is set

### DIFF
--- a/src/services/mcp-client/client.ts
+++ b/src/services/mcp-client/client.ts
@@ -56,6 +56,11 @@ export class StitchMCPClient implements StitchMCPClientSpec {
    * Validates the token against Google's tokeninfo endpoint.
    */
   private async validateToken() {
+    // Skip OAuth token validation entirely when using API key authentication
+    if (this.config.apiKey) {
+      return;
+    }
+
     if (!this.config.accessToken) {
          try {
             const newToken = this.refreshGcloudToken();

--- a/tests/services/mcp-client/client.test.ts
+++ b/tests/services/mcp-client/client.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { StitchMCPClient } from "../../../src/services/mcp-client/client.js";
+import { execSync } from "child_process";
+
+// Mock child_process
+mock.module("child_process", () => ({
+  execSync: mock(),
+}));
+
+describe("StitchMCPClient", () => {
+  beforeEach(() => {
+     // Reset mocks
+     (execSync as any).mockReset();
+  });
+
+  it("should skip OAuth validation when API key is present", async () => {
+    // Setup
+    const client = new StitchMCPClient({
+      apiKey: "test-api-key",
+      projectId: "test-project"
+    });
+
+    // Mock fetch to fail if called (which would trigger re-auth flow in original code)
+    global.fetch = mock(async () => ({
+      ok: false,
+      status: 401
+    } as Response));
+
+    // Mock execSync to throw like gcloud missing
+    (execSync as any).mockImplementation(() => {
+      throw new Error("Command not found: gcloud");
+    });
+
+    // Access private method
+    const validateToken = (client as any).validateToken.bind(client);
+
+    // Act
+    await validateToken();
+
+    // Assert
+    // execSync should NOT be called if we have API key (with the fix)
+    // If without fix, it WILL be called.
+    expect(execSync).toHaveBeenCalledTimes(0);
+  });
+});


### PR DESCRIPTION
Fixes an issue where `validateToken` would attempt to refresh the gcloud token even when an API key was present, causing crashes on systems without gcloud. Added an early return to `validateToken` to skip OAuth validation if `apiKey` is set. Added a test case to verify this behavior.

---
*PR created automatically by Jules for task [15165608324006014220](https://jules.google.com/task/15165608324006014220) started by @davideast*