### PR TITLE
Implement serve behaviors for HTML preview in JsonTree

### DIFF
--- a/src/ui/serve-behaviors/handlers.test.ts
+++ b/src/ui/serve-behaviors/handlers.test.ts
@@ -1,0 +1,42 @@
+import { test, expect, describe, mock, beforeEach, afterEach, spyOn } from 'bun:test';
+import { htmlCodeServeHandler, deps } from './handlers.js';
+import type { ServeContext } from './types.js';
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  globalThis.fetch = mock(() => Promise.resolve({ ok: true, text: () => Promise.resolve('<html></html>') } as Response));
+
+  // Spy on the dependency
+  spyOn(deps, 'serveHtmlInMemory').mockImplementation(
+    () => Promise.resolve({ url: 'http://127.0.0.1:3456', stop: () => {} })
+  );
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  // Restore all mocks
+  mock.restore();
+});
+
+describe('htmlCodeServeHandler', () => {
+  test('returns success with URL', async () => {
+    const ctx: ServeContext = { key: 'downloadUrl', value: 'https://example.com/code.html', path: 'screen.htmlCode.downloadUrl' };
+    const result = await htmlCodeServeHandler.serve(ctx);
+    expect(result.success).toBe(true);
+    expect(result.url).toBeDefined();
+    expect(deps.serveHtmlInMemory).toHaveBeenCalled();
+  });
+
+  test('extracts URL from object with downloadUrl', async () => {
+    const ctx: ServeContext = { key: 'htmlCode', value: { downloadUrl: 'https://example.com/code.html' }, path: 'screen.htmlCode' };
+    const result = await htmlCodeServeHandler.serve(ctx);
+    expect(result.success).toBe(true);
+  });
+
+  test('fails if no URL found', async () => {
+    const ctx: ServeContext = { key: 'htmlCode', value: 12345, path: 'screen.htmlCode' };
+    const result = await htmlCodeServeHandler.serve(ctx);
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/ui/serve-behaviors/handlers.ts
+++ b/src/ui/serve-behaviors/handlers.ts
@@ -1,0 +1,41 @@
+/**
+ * Serve handlers - isolated behavior implementations.
+ */
+import type { ServeHandler, ServeContext, ServeResult } from './types.js';
+import { serveHtmlInMemory } from './server.js';
+
+// Export dependencies for testing
+export const deps = {
+  serveHtmlInMemory
+};
+
+export const htmlCodeServeHandler: ServeHandler = {
+  async serve(ctx: ServeContext): Promise<ServeResult> {
+    try {
+      // Extract URL - either from value directly or from value.downloadUrl
+      let url: string;
+      if (typeof ctx.value === 'string') {
+        url = ctx.value;
+      } else if (typeof ctx.value === 'object' && ctx.value?.downloadUrl) {
+        url = ctx.value.downloadUrl;
+      } else {
+        return { success: false, message: 'No download URL found' };
+      }
+
+      ctx.onProgress?.('📥 Downloading HTML...');
+      const response = await fetch(url);
+      if (!response.ok) {
+        return { success: false, message: `Download failed: ${response.status} ${response.statusText}` };
+      }
+      const html = await response.text();
+
+      ctx.onProgress?.('🚀 Starting local server...');
+      const { url: serveUrl } = await deps.serveHtmlInMemory(html);
+
+      ctx.onProgress?.('🌐 Opening browser...');
+      return { success: true, message: `🌐 Preview at ${serveUrl} (auto-closes in 5 min)`, url: serveUrl };
+    } catch (error) {
+      return { success: false, message: `Serve failed: ${error instanceof Error ? error.message : String(error)}` };
+    }
+  },
+};

--- a/src/ui/serve-behaviors/index.ts
+++ b/src/ui/serve-behaviors/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Serve behaviors for JSON viewer.
+ */
+export type { ServeHandler, ServeContext, ServeResult, PathMatcher } from './types.js';
+export { serveHtmlInMemory } from './server.js';
+export { htmlCodeServeHandler } from './handlers.js';
+export { registerServeHandler, getServeHandler, endsWith, contains } from './registry.js';

--- a/src/ui/serve-behaviors/registry.test.ts
+++ b/src/ui/serve-behaviors/registry.test.ts
@@ -1,0 +1,30 @@
+import { test, expect, describe } from 'bun:test';
+import { getServeHandler, endsWith, contains } from './registry.js';
+
+describe('serve registry', () => {
+  test('returns handler for .htmlCode path', () => {
+    expect(getServeHandler('screen.htmlCode')).not.toBeNull();
+  });
+
+  test('returns handler for .htmlCode.downloadUrl path', () => {
+    expect(getServeHandler('screen.htmlCode.downloadUrl')).not.toBeNull();
+  });
+
+  test('returns null for unregistered paths', () => {
+    expect(getServeHandler('screen.title')).toBeNull();
+  });
+});
+
+describe('path matchers', () => {
+  test('endsWith matches suffix', () => {
+    const matcher = endsWith('.htmlCode');
+    expect(matcher('screen.htmlCode')).toBe(true);
+    expect(matcher('screen.htmlCode.downloadUrl')).toBe(false);
+  });
+
+  test('contains matches segment', () => {
+    const matcher = contains('htmlCode');
+    expect(matcher('screen.htmlCode')).toBe(true);
+    expect(matcher('screen.title')).toBe(false);
+  });
+});

--- a/src/ui/serve-behaviors/registry.ts
+++ b/src/ui/serve-behaviors/registry.ts
@@ -1,0 +1,34 @@
+/**
+ * Registry for path-based serve handler selection.
+ */
+import type { ServeHandler, PathMatcher } from './types.js';
+import { htmlCodeServeHandler } from './handlers.js';
+
+interface HandlerRegistration { matcher: PathMatcher; handler: ServeHandler; }
+const registrations: HandlerRegistration[] = [];
+
+export function registerServeHandler(matcher: PathMatcher, handler: ServeHandler): void {
+  registrations.push({ matcher, handler });
+}
+
+export function getServeHandler(path: string): ServeHandler | null {
+  for (let i = registrations.length - 1; i >= 0; i--) {
+    const reg = registrations[i];
+    if (reg && reg.matcher(path)) return reg.handler;
+  }
+  return null;
+}
+
+export function endsWith(suffix: string): PathMatcher {
+  return (path: string) => path.endsWith(suffix);
+}
+
+export function contains(segment: string): PathMatcher {
+  return (path: string) => path.includes(segment);
+}
+
+// Default registrations
+registerServeHandler(endsWith('.htmlCode'), htmlCodeServeHandler);
+registerServeHandler(endsWith('.htmlCode.downloadUrl'), htmlCodeServeHandler);
+
+export { htmlCodeServeHandler };


### PR DESCRIPTION
Implemented the `serve-behaviors` module to allow previewing HTML content from the JSON viewer. Added `htmlCodeServeHandler` which downloads and serves HTML content using `serveHtmlInMemory`. Integrated this into `JsonTree` component with the 's' key shortcut. Added comprehensive tests for the new functionality and refactored `handlers.ts` to support dependency injection for better test isolation in Bun.

---
*PR created automatically by Jules for task [14898192721699292027](https://jules.google.com/task/14898192721699292027) started by @davideast*