### PR TITLE
feat: Add API key to doctor check

### DIFF
--- a/src/commands/doctor/context.ts
+++ b/src/commands/doctor/context.ts
@@ -12,6 +12,10 @@ export interface DoctorContext {
   gcloudService: GcloudService;
   stitchService: StitchService;
 
+  // Auth mode
+  authMode: 'apiKey' | 'oauth';
+  apiKey?: string;
+
   // State
   checks: Array<{
     name: string;

--- a/src/commands/doctor/handler.ts
+++ b/src/commands/doctor/handler.ts
@@ -8,11 +8,14 @@ import { createSpinner } from '../../ui/spinner.js';
 import { ConsoleUI } from '../../framework/ConsoleUI.js';
 import { type DoctorContext } from './context.js';
 import { type CommandStep } from '../../framework/CommandStep.js';
+import dotenv from 'dotenv';
 
+import { ApiKeyDetectedStep } from './steps/ApiKeyDetectedStep.js';
 import { GcloudCheckStep } from './steps/GcloudCheckStep.js';
 import { AuthCheckStep } from './steps/AuthCheckStep.js';
 import { AdcCheckStep } from './steps/AdcCheckStep.js';
 import { ProjectCheckStep } from './steps/ProjectCheckStep.js';
+import { ApiKeyConnectionStep } from './steps/ApiKeyConnectionStep.js';
 import { ApiCheckStep } from './steps/ApiCheckStep.js';
 
 export class DoctorHandler implements DoctorCommand {
@@ -23,20 +26,27 @@ export class DoctorHandler implements DoctorCommand {
     private readonly stitchService: StitchService = new StitchHandler()
   ) {
     this.steps = [
+      new ApiKeyDetectedStep(),
       new GcloudCheckStep(),
       new AuthCheckStep(),
       new AdcCheckStep(),
       new ProjectCheckStep(),
+      new ApiKeyConnectionStep(),
       new ApiCheckStep(),
     ];
   }
 
   async execute(input: DoctorInput): Promise<DoctorResult> {
+    dotenv.config();
+    const apiKey = process.env.STITCH_API_KEY;
+
     const context: DoctorContext = {
       input,
       ui: new ConsoleUI(),
       gcloudService: this.gcloudService,
       stitchService: this.stitchService,
+      authMode: apiKey ? 'apiKey' : 'oauth',
+      apiKey: apiKey || undefined,
       checks: []
     };
 

--- a/src/commands/doctor/steps/AdcCheckStep.ts
+++ b/src/commands/doctor/steps/AdcCheckStep.ts
@@ -6,7 +6,7 @@ export class AdcCheckStep implements CommandStep<DoctorContext> {
   name = 'Checking application credentials...';
 
   async shouldRun(context: DoctorContext): Promise<boolean> {
-    return true;
+    return context.authMode === 'oauth';
   }
 
   async run(context: DoctorContext): Promise<StepResult> {

--- a/src/commands/doctor/steps/ApiCheckStep.ts
+++ b/src/commands/doctor/steps/ApiCheckStep.ts
@@ -6,6 +6,7 @@ export class ApiCheckStep implements CommandStep<DoctorContext> {
   name = 'Testing Stitch API...';
 
   async shouldRun(context: DoctorContext): Promise<boolean> {
+    if (context.authMode !== 'oauth') return false;
     // Only run if we have a project
     const projectCheck = context.checks.find(c => c.name === 'Active Project');
     return !!projectCheck && projectCheck.passed;

--- a/src/commands/doctor/steps/ApiKeyConnectionStep.ts
+++ b/src/commands/doctor/steps/ApiKeyConnectionStep.ts
@@ -1,0 +1,39 @@
+import { type CommandStep, type StepResult } from '../../../framework/CommandStep.js';
+import { type DoctorContext } from '../context.js';
+
+export class ApiKeyConnectionStep implements CommandStep<DoctorContext> {
+  id = 'api-key-connection';
+  name = 'Testing Stitch API...';
+
+  async shouldRun(context: DoctorContext): Promise<boolean> {
+    if (context.authMode !== 'apiKey') return false;
+    const apiKeyCheck = context.checks.find(c => c.name === 'API Key');
+    return !!apiKeyCheck && apiKeyCheck.passed;
+  }
+
+  async run(context: DoctorContext): Promise<StepResult> {
+    const testResult = await context.stitchService.testConnectionWithApiKey({
+      apiKey: context.apiKey!,
+    });
+
+    if (testResult.success) {
+      const message = `Healthy (${testResult.data.statusCode})`;
+      context.checks.push({
+        name: 'Stitch API',
+        passed: true,
+        message,
+      });
+      return { success: true, detail: message };
+    } else {
+      const message = testResult.error.message;
+      context.checks.push({
+        name: 'Stitch API',
+        passed: false,
+        message,
+        suggestion: testResult.error.suggestion,
+        details: testResult.error.details,
+      });
+      return { success: false, error: new Error(message) };
+    }
+  }
+}

--- a/src/commands/doctor/steps/ApiKeyDetectedStep.ts
+++ b/src/commands/doctor/steps/ApiKeyDetectedStep.ts
@@ -1,0 +1,37 @@
+import { type CommandStep, type StepResult } from '../../../framework/CommandStep.js';
+import { type DoctorContext } from '../context.js';
+
+export class ApiKeyDetectedStep implements CommandStep<DoctorContext> {
+  id = 'api-key-detected';
+  name = 'Checking API Key...';
+
+  async shouldRun(context: DoctorContext): Promise<boolean> {
+    return context.authMode === 'apiKey';
+  }
+
+  async run(context: DoctorContext): Promise<StepResult> {
+    const apiKey = context.apiKey;
+
+    if (!apiKey || apiKey.trim().length === 0) {
+      const message = 'STITCH_API_KEY is set but empty';
+      context.checks.push({
+        name: 'API Key',
+        passed: false,
+        message,
+        suggestion: 'Set a valid API key in STITCH_API_KEY environment variable or in your .env file',
+      });
+      return { success: false, error: new Error(message) };
+    }
+
+    const masked = apiKey.length > 7
+      ? `${apiKey.slice(0, 4)}...${apiKey.slice(-3)}`
+      : '***';
+    const message = `Detected (${masked})`;
+    context.checks.push({
+      name: 'API Key',
+      passed: true,
+      message,
+    });
+    return { success: true, detail: message };
+  }
+}

--- a/src/commands/doctor/steps/AuthCheckStep.ts
+++ b/src/commands/doctor/steps/AuthCheckStep.ts
@@ -6,7 +6,7 @@ export class AuthCheckStep implements CommandStep<DoctorContext> {
   name = 'Checking user authentication...';
 
   async shouldRun(context: DoctorContext): Promise<boolean> {
-    return true;
+    return context.authMode === 'oauth';
   }
 
   async run(context: DoctorContext): Promise<StepResult> {

--- a/src/commands/doctor/steps/GcloudCheckStep.ts
+++ b/src/commands/doctor/steps/GcloudCheckStep.ts
@@ -6,7 +6,7 @@ export class GcloudCheckStep implements CommandStep<DoctorContext> {
   name = 'Checking Google Cloud CLI...';
 
   async shouldRun(context: DoctorContext): Promise<boolean> {
-    return true;
+    return context.authMode === 'oauth';
   }
 
   async run(context: DoctorContext): Promise<StepResult> {

--- a/src/commands/doctor/steps/ProjectCheckStep.ts
+++ b/src/commands/doctor/steps/ProjectCheckStep.ts
@@ -6,7 +6,7 @@ export class ProjectCheckStep implements CommandStep<DoctorContext> {
   name = 'Checking active project...';
 
   async shouldRun(context: DoctorContext): Promise<boolean> {
-    return true;
+    return context.authMode === 'oauth';
   }
 
   async run(context: DoctorContext): Promise<StepResult> {

--- a/src/services/stitch/spec.ts
+++ b/src/services/stitch/spec.ts
@@ -21,6 +21,11 @@ export const TestConnectionInputSchema = z.object({
 });
 export type TestConnectionInput = z.infer<typeof TestConnectionInputSchema>;
 
+export const TestConnectionWithApiKeyInputSchema = z.object({
+  apiKey: z.string().min(1),
+});
+export type TestConnectionWithApiKeyInput = z.infer<typeof TestConnectionWithApiKeyInputSchema>;
+
 // ============================================================================
 // ERROR CODES
 // ============================================================================
@@ -121,6 +126,11 @@ export interface StitchService {
   * Test the connection to the Stitch API
    */
   testConnection(input: TestConnectionInput): Promise<ConnectionTestResult>;
+
+  /**
+   * Test the connection to the Stitch API using an API key
+   */
+  testConnectionWithApiKey(input: TestConnectionWithApiKeyInput): Promise<ConnectionTestResult>;
 
   /**
    * Check if a user has a specific IAM role on a project


### PR DESCRIPTION
## Add API check to doctor command

Checks the existence of `process.env.STITCH_API_KEY`.

```
npx @_davideast/stitch-mcp doctor

Stitch Doctor

✔ Detected (AQ.A...foA)
✔ Healthy (200)

────────────────────────────────────────────────────────────

Health Check Summary

✔ API Key: Detected (AQ.A...foA)
✔ Stitch API: Healthy (200)

All checks passed!
```