### PR TITLE
feat: persist screen selections and routes across sessions

### DIFF
--- a/src/commands/site/ui/components/StatusIcon.tsx
+++ b/src/commands/site/ui/components/StatusIcon.tsx
@@ -2,12 +2,15 @@ import React from 'react';
 import { Text } from 'ink';
 
 interface StatusIconProps {
-  status: 'included' | 'ignored';
+  status: 'included' | 'ignored' | 'discarded';
 }
 
 export const StatusIcon: React.FC<StatusIconProps> = ({ status }) => {
   if (status === 'included') {
     return <Text color="green">✔ </Text>;
+  }
+  if (status === 'discarded') {
+    return <Text color="red">✖ </Text>;
   }
   return <Text color="gray">- </Text>;
 };

--- a/src/commands/site/utils/SiteManifest.test.ts
+++ b/src/commands/site/utils/SiteManifest.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import fs from 'fs-extra';
+import path from 'path';
+import os from 'os';
+import { SiteManifest } from './SiteManifest.js';
+
+const TEST_PROJECT_ID = 'test-project-manifest';
+const baseDir = path.join(os.homedir(), '.stitch-mcp', 'site', TEST_PROJECT_ID);
+const manifestPath = path.join(baseDir, 'site-manifest.json');
+const legacyPath = path.join(baseDir, 'discarded.json');
+
+beforeEach(async () => {
+  await fs.remove(baseDir);
+});
+
+afterEach(async () => {
+  await fs.remove(baseDir);
+});
+
+describe('SiteManifest', () => {
+  it('load() returns empty Map when no file exists', async () => {
+    const manifest = new SiteManifest(TEST_PROJECT_ID);
+    const result = await manifest.load();
+    expect(result.size).toBe(0);
+  });
+
+  it('save() then load() round-trips screen state', async () => {
+    const manifest = new SiteManifest(TEST_PROJECT_ID);
+    const screens = [
+      { id: 'a', status: 'included', route: '/about' },
+      { id: 'b', status: 'discarded', route: '' },
+      { id: 'c', status: 'ignored', route: '/contact' },
+    ];
+    await manifest.save(screens);
+    const result = await manifest.load();
+
+    expect(result.get('a')).toEqual({ status: 'included', route: '/about' });
+    expect(result.get('b')).toEqual({ status: 'discarded' });
+    expect(result.get('c')).toEqual({ route: '/contact' });
+  });
+
+  it('only non-default state is persisted', async () => {
+    const manifest = new SiteManifest(TEST_PROJECT_ID);
+    const screens = [
+      { id: 'default', status: 'ignored', route: '' },
+      { id: 'included', status: 'included', route: '' },
+    ];
+    await manifest.save(screens);
+
+    const raw = await fs.readJson(manifestPath);
+    expect(raw.screens['default']).toBeUndefined();
+    expect(raw.screens['included']).toEqual({ status: 'included' });
+  });
+
+  it('included status persists', async () => {
+    const manifest = new SiteManifest(TEST_PROJECT_ID);
+    await manifest.save([{ id: 's1', status: 'included', route: '' }]);
+    const result = await manifest.load();
+    expect(result.get('s1')?.status).toBe('included');
+  });
+
+  it('discarded status persists', async () => {
+    const manifest = new SiteManifest(TEST_PROJECT_ID);
+    await manifest.save([{ id: 's1', status: 'discarded', route: '' }]);
+    const result = await manifest.load();
+    expect(result.get('s1')?.status).toBe('discarded');
+  });
+
+  it('routes persist', async () => {
+    const manifest = new SiteManifest(TEST_PROJECT_ID);
+    await manifest.save([{ id: 's1', status: 'included', route: '/home' }]);
+    const result = await manifest.load();
+    expect(result.get('s1')?.route).toBe('/home');
+  });
+
+  it('screen with only a route (status ignored) persists', async () => {
+    const manifest = new SiteManifest(TEST_PROJECT_ID);
+    await manifest.save([{ id: 's1', status: 'ignored', route: '/page' }]);
+    const result = await manifest.load();
+    expect(result.get('s1')).toEqual({ route: '/page' });
+    expect(result.get('s1')?.status).toBeUndefined();
+  });
+
+  it('legacy discarded.json migration works', async () => {
+    await fs.ensureDir(baseDir);
+    await fs.writeJson(legacyPath, { discardedScreenIds: ['x', 'y'] });
+
+    const manifest = new SiteManifest(TEST_PROJECT_ID);
+    const result = await manifest.load();
+    expect(result.get('x')).toEqual({ status: 'discarded' });
+    expect(result.get('y')).toEqual({ status: 'discarded' });
+    expect(result.size).toBe(2);
+  });
+
+  it('legacy migration only runs when site-manifest.json is missing', async () => {
+    await fs.ensureDir(baseDir);
+    // Write both files — manifest should take precedence
+    await fs.writeJson(manifestPath, {
+      screens: { 'a': { status: 'included', route: '/real' } }
+    });
+    await fs.writeJson(legacyPath, { discardedScreenIds: ['a'] });
+
+    const manifest = new SiteManifest(TEST_PROJECT_ID);
+    const result = await manifest.load();
+    expect(result.get('a')).toEqual({ status: 'included', route: '/real' });
+  });
+
+  it('save() creates parent directories', async () => {
+    // Ensure the directory doesn't exist
+    await fs.remove(baseDir);
+    const manifest = new SiteManifest(TEST_PROJECT_ID);
+    await manifest.save([{ id: 's1', status: 'included', route: '/test' }]);
+
+    const exists = await fs.pathExists(manifestPath);
+    expect(exists).toBe(true);
+  });
+
+  it('load() handles corrupted JSON gracefully', async () => {
+    await fs.ensureDir(baseDir);
+    await fs.writeFile(manifestPath, '{not valid json!!!');
+
+    const manifest = new SiteManifest(TEST_PROJECT_ID);
+    const result = await manifest.load();
+    // Falls through to legacy check, which also doesn't exist → empty map
+    expect(result.size).toBe(0);
+  });
+});

--- a/src/commands/site/utils/SiteManifest.ts
+++ b/src/commands/site/utils/SiteManifest.ts
@@ -1,0 +1,66 @@
+import fs from 'fs-extra';
+import path from 'path';
+import os from 'os';
+
+interface ScreenState {
+  status?: 'included' | 'ignored' | 'discarded';
+  route?: string;
+}
+
+interface SiteManifestData {
+  screens: Record<string, ScreenState>;
+}
+
+interface LegacyDiscardData {
+  discardedScreenIds: string[];
+}
+
+export class SiteManifest {
+  private filePath: string;
+  private legacyPath: string;
+
+  constructor(projectId: string) {
+    const dir = path.join(os.homedir(), '.stitch-mcp', 'site', projectId);
+    this.filePath = path.join(dir, 'site-manifest.json');
+    this.legacyPath = path.join(dir, 'discarded.json');
+  }
+
+  async load(): Promise<Map<string, ScreenState>> {
+    try {
+      const data: SiteManifestData = await fs.readJson(this.filePath);
+      return new Map(Object.entries(data.screens || {}));
+    } catch {
+      // site-manifest.json doesn't exist or is corrupted — try legacy migration
+    }
+
+    try {
+      const legacy: LegacyDiscardData = await fs.readJson(this.legacyPath);
+      const map = new Map<string, ScreenState>();
+      for (const id of legacy.discardedScreenIds || []) {
+        map.set(id, { status: 'discarded' });
+      }
+      return map;
+    } catch {
+      return new Map();
+    }
+  }
+
+  async save(screens: { id: string; status: string; route: string }[]): Promise<void> {
+    const record: Record<string, ScreenState> = {};
+    for (const screen of screens) {
+      const entry: ScreenState = {};
+      if (screen.status !== 'ignored') {
+        entry.status = screen.status as ScreenState['status'];
+      }
+      if (screen.route !== '') {
+        entry.route = screen.route;
+      }
+      if (entry.status || entry.route) {
+        record[screen.id] = entry;
+      }
+    }
+    await fs.ensureDir(path.dirname(this.filePath));
+    const data: SiteManifestData = { screens: record };
+    await fs.writeJson(this.filePath, data, { spaces: 2 });
+  }
+}

--- a/src/lib/services/site/types.ts
+++ b/src/lib/services/site/types.ts
@@ -9,7 +9,7 @@ export interface UIScreen {
   id: string;          // RemoteScreen.name
   title: string;       // RemoteScreen.title
   downloadUrl: string; // RemoteScreen.htmlCode.downloadUrl
-  status: 'included' | 'ignored';
+  status: 'included' | 'ignored' | 'discarded';
   route: string;       // empty by default
 }
 


### PR DESCRIPTION
Replace DiscardManifest with unified SiteManifest that stores all per-screen state (status, route) in site-manifest.json. Selections and routes now survive across sessions. Includes legacy migration from discarded.json and discard/undiscard UI support.