### PR TITLE
🔒 Fix shell injection vulnerability in execCommand on Windows

### DIFF
--- a/src/platform/shell.test.ts
+++ b/src/platform/shell.test.ts
@@ -1,0 +1,80 @@
+import { describe, test, expect, spyOn, beforeEach, afterEach } from 'bun:test';
+import { execCommand } from './shell';
+import * as childProcess from 'node:child_process';
+import { EventEmitter } from 'events';
+
+class MockChildProcess extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  kill() {}
+}
+
+describe('execCommand security', () => {
+  let originalPlatform: string;
+  let spawnSpy: any;
+
+  beforeEach(() => {
+    originalPlatform = process.platform;
+    // Mock spawn to return a fake process and capture arguments
+    spawnSpy = spyOn(childProcess, 'spawn').mockImplementation((cmd, args, opts) => {
+        const child = new MockChildProcess();
+        setTimeout(() => {
+            child.emit('close', 0);
+        }, 1);
+        return child as any;
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+    spawnSpy.mockRestore();
+  });
+
+  test('should use safe shell execution on Linux', async () => {
+    // Force Linux platform
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+
+    await execCommand(['ls', '-la']);
+
+    expect(spawnSpy).toHaveBeenCalled();
+    const [cmd, args, opts] = spawnSpy.mock.calls[0];
+    expect(cmd).toBe('ls');
+    expect(args).toEqual(['-la']);
+    expect(opts.shell).toBe(false);
+  });
+
+  test('should use safe cmd.exe invocation on Windows', async () => {
+    // Force Windows platform
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+
+    await execCommand(['echo', 'hello']);
+
+    expect(spawnSpy).toHaveBeenCalled();
+    const [cmd, args, opts] = spawnSpy.mock.calls[0];
+
+    // We expect the safe implementation:
+    // cmd.exe /d /s /c echo hello
+    // with shell: false
+    expect(cmd).toBe('cmd.exe');
+    expect(args).toEqual(['/d', '/s', '/c', 'echo', 'hello']);
+    expect(opts.shell).toBe(false);
+  });
+
+  test('should use safe cmd.exe invocation on Windows (streaming)', async () => {
+    // Force Windows platform
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+
+    // We need to import execCommandStreaming but I didn't import it yet.
+    // I will fix imports.
+    const { execCommandStreaming } = await import('./shell');
+
+    await execCommandStreaming(['echo', 'hello']);
+
+    expect(spawnSpy).toHaveBeenCalled();
+    const [cmd, args, opts] = spawnSpy.mock.calls[0];
+
+    expect(cmd).toBe('cmd.exe');
+    expect(args).toEqual(['/d', '/s', '/c', 'echo', 'hello']);
+    expect(opts.shell).toBe(false);
+  });
+});

--- a/src/platform/shell.ts
+++ b/src/platform/shell.ts
@@ -8,6 +8,16 @@ export interface ShellResult {
   error?: string;
 }
 
+function getSpawnArgs(command: string, args: string[]) {
+  if (process.platform === 'win32') {
+    return {
+      cmd: 'cmd.exe',
+      args: ['/d', '/s', '/c', command, ...args]
+    };
+  }
+  return { cmd: command, args };
+}
+
 /**
  * Execute a shell command and return the result
  */
@@ -25,10 +35,11 @@ export async function execCommand(command: string[], options?: { cwd?: string; e
       env: { ...process.env, ...(options?.env || {}) },
       stdio: 'pipe',
       timeout: options?.timeout,
-      shell: process.platform === 'win32'
+      shell: false
     };
 
-    const child = spawn(cmd, args, spawnOptions) as ChildProcess;
+    const { cmd: spawnCmd, args: spawnArgs } = getSpawnArgs(cmd, args);
+    const child = spawn(spawnCmd, spawnArgs, spawnOptions) as ChildProcess;
 
     if (child.stdout) {
       child.stdout.on('data', (data: Buffer) => {
@@ -84,10 +95,11 @@ export async function execCommandStreaming(
       cwd: options?.cwd || process.cwd(),
       env: { ...process.env, ...(options?.env || {}) },
       stdio: 'pipe',
-      shell: process.platform === 'win32'
+      shell: false
     };
 
-    const child = spawn(cmd, args, spawnOptions) as ChildProcess;
+    const { cmd: spawnCmd, args: spawnArgs } = getSpawnArgs(cmd, args);
+    const child = spawn(spawnCmd, spawnArgs, spawnOptions) as ChildProcess;
 
     if (child.stdout) {
       child.stdout.on('data', (buffer: Buffer) => {


### PR DESCRIPTION
🎯 **What:** Fixed a potential command injection vulnerability in `execCommand` and `execCommandStreaming` on Windows.
⚠️ **Risk:** The previous implementation used `shell: true` on Windows, which could allow arbitrary command execution if arguments contained unescaped shell metacharacters.
🛡️ **Solution:** Replaced `shell: true` with `shell: false` (default) and manually invoked `cmd.exe /d /s /c` with arguments passed as an array. This leverages Node.js's internal argument escaping for `spawn`, ensuring arguments are treated as literals.
Added `src/platform/shell.test.ts` to verify correct behavior on Windows and Linux.

---
*PR created automatically by Jules for task [4947142302670410482](https://jules.google.com/task/4947142302670410482) started by @davideast*