### PR TITLE
feat(site): add --export flag and `e` key to export build_site config

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ npx @_davideast/stitch-mcp site -p <project-id> [options]
 |--------|-------------|
 | `-p, --project <id>` | **Required.** Project ID |
 | `-o, --output <dir>` | Output directory (default: `.`) |
+| `-e, --export` | Export screen-to-route config as `build_site` JSON (no interactive UI) |
 
 Launches an interactive screen-to-route mapper, then generates an Astro project with the following structure:
 
@@ -140,6 +141,8 @@ Launches an interactive screen-to-route mapper, then generates an Astro project 
 ```
 
 External assets (fonts, images) are downloaded to `public/assets/` with URLs rewritten to local paths.
+
+Press `e` in the interactive builder to export the current screen-to-route config as JSON to stdout (useful for piping into `build_site`).
 
 ### `view` — Interactive resource browser
 

--- a/src/commands/site/command.ts
+++ b/src/commands/site/command.ts
@@ -8,7 +8,8 @@ export const command: CommandDefinition = {
     { flags: '-p, --project <id>', description: 'Project ID' }
   ],
   options: [
-    { flags: '-o, --output <dir>', description: 'Output directory', defaultValue: '.' }
+    { flags: '-o, --output <dir>', description: 'Output directory', defaultValue: '.' },
+    { flags: '-e, --export', description: 'Export screen-to-route config as build_site JSON', defaultValue: false }
   ],
   action: async (_args, options) => {
     try {
@@ -16,7 +17,8 @@ export const command: CommandDefinition = {
       const handler = new SiteCommandHandler();
       await handler.execute({
           projectId: options.project,
-          outputDir: options.output
+          outputDir: options.output,
+          export: options.export
       });
       process.exit(0);
     } catch (error) {

--- a/src/commands/site/export.test.ts
+++ b/src/commands/site/export.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import fs from 'fs-extra';
+import path from 'path';
+import os from 'os';
+import { SiteCommandHandler } from './index.js';
+import { SiteManifest } from './utils/SiteManifest.js';
+import type { RemoteScreen } from '../../lib/services/site/types.js';
+
+const TEST_PROJECT_ID = 'test-export-project';
+const baseDir = path.join(os.homedir(), '.stitch-mcp', 'site', TEST_PROJECT_ID);
+
+function makeClient(screens: RemoteScreen[]) {
+  return {
+    callTool: async (_name: string, _args: Record<string, any>) => ({
+      screens,
+    }),
+  } as any;
+}
+
+const remoteScreens: RemoteScreen[] = [
+  { name: 'screen-a', title: 'Home', htmlCode: { downloadUrl: 'https://example.com/a.html' } },
+  { name: 'screen-b', title: 'About', htmlCode: { downloadUrl: 'https://example.com/b.html' } },
+  { name: 'screen-c', title: 'Contact', htmlCode: { downloadUrl: 'https://example.com/c.html' } },
+];
+
+describe('site --export', () => {
+  let originalLog: typeof console.log;
+  let logged: string[];
+
+  beforeEach(async () => {
+    await fs.remove(baseDir);
+    originalLog = console.log;
+    logged = [];
+    console.log = (...args: any[]) => {
+      logged.push(args.map(String).join(' '));
+    };
+  });
+
+  afterEach(async () => {
+    console.log = originalLog;
+    await fs.remove(baseDir);
+  });
+
+  it('outputs JSON with included screens and their routes', async () => {
+    // Save manifest state: screen-a included with route, screen-b included with route
+    const manifest = new SiteManifest(TEST_PROJECT_ID);
+    await manifest.save([
+      { id: 'screen-a', status: 'included', route: '/' },
+      { id: 'screen-b', status: 'included', route: '/about' },
+      { id: 'screen-c', status: 'ignored', route: '' },
+    ]);
+
+    const handler = new SiteCommandHandler(makeClient(remoteScreens));
+    await handler.execute({ projectId: TEST_PROJECT_ID, export: true });
+
+    expect(logged.length).toBe(1);
+    const output = JSON.parse(logged[0]);
+    expect(output).toEqual({
+      projectId: TEST_PROJECT_ID,
+      routes: [
+        { screenId: 'screen-a', route: '/' },
+        { screenId: 'screen-b', route: '/about' },
+      ],
+    });
+  });
+
+  it('outputs empty routes when no screens are included', async () => {
+    const handler = new SiteCommandHandler(makeClient(remoteScreens));
+    await handler.execute({ projectId: TEST_PROJECT_ID, export: true });
+
+    expect(logged.length).toBe(1);
+    const output = JSON.parse(logged[0]);
+    expect(output).toEqual({
+      projectId: TEST_PROJECT_ID,
+      routes: [],
+    });
+  });
+
+  it('excludes discarded screens from export', async () => {
+    const manifest = new SiteManifest(TEST_PROJECT_ID);
+    await manifest.save([
+      { id: 'screen-a', status: 'included', route: '/' },
+      { id: 'screen-b', status: 'discarded', route: '/about' },
+    ]);
+
+    const handler = new SiteCommandHandler(makeClient(remoteScreens));
+    await handler.execute({ projectId: TEST_PROJECT_ID, export: true });
+
+    const output = JSON.parse(logged[0]);
+    expect(output.routes).toEqual([
+      { screenId: 'screen-a', route: '/' },
+    ]);
+  });
+
+  it('skips screens without htmlCode', async () => {
+    const screensWithMissing: RemoteScreen[] = [
+      { name: 'screen-a', title: 'Home', htmlCode: { downloadUrl: 'https://example.com/a.html' } },
+      { name: 'screen-no-html', title: 'No HTML' } as RemoteScreen,
+    ];
+
+    const manifest = new SiteManifest(TEST_PROJECT_ID);
+    await manifest.save([
+      { id: 'screen-a', status: 'included', route: '/' },
+      { id: 'screen-no-html', status: 'included', route: '/missing' },
+    ]);
+
+    const handler = new SiteCommandHandler(makeClient(screensWithMissing));
+    await handler.execute({ projectId: TEST_PROJECT_ID, export: true });
+
+    const output = JSON.parse(logged[0]);
+    // screen-no-html is filtered out by toUIScreens since it has no htmlCode
+    expect(output.routes).toEqual([
+      { screenId: 'screen-a', route: '/' },
+    ]);
+  });
+
+  it('does not launch interactive UI when export is true', async () => {
+    const handler = new SiteCommandHandler(makeClient(remoteScreens));
+    // If it tried to render, it would hang or throw because there's no TTY.
+    // A clean return means the interactive path was skipped.
+    await handler.execute({ projectId: TEST_PROJECT_ID, export: true });
+    expect(logged.length).toBe(1);
+  });
+});

--- a/src/commands/site/index.tsx
+++ b/src/commands/site/index.tsx
@@ -4,11 +4,14 @@ import { StitchMCPClient } from '../../services/mcp-client/client.js';
 import { SiteBuilder } from './ui/SiteBuilder.js';
 import { SiteService } from '../../lib/services/site/SiteService.js';
 import { AssetGateway } from '../../lib/server/AssetGateway.js';
+import { ProjectSyncer } from './utils/ProjectSyncer.js';
+import { SiteManifest } from './utils/SiteManifest.js';
 import type { SiteConfig } from '../../lib/services/site/types.js';
 
 interface SiteCommandOptions {
   projectId: string;
   outputDir?: string;
+  export?: boolean;
 }
 
 export class SiteCommandHandler {
@@ -16,6 +19,31 @@ export class SiteCommandHandler {
 
   async execute(options: SiteCommandOptions) {
     const client = this.client || new StitchMCPClient();
+
+    if (options.export) {
+      const syncer = new ProjectSyncer(client);
+      const remoteScreens = await syncer.fetchManifest(options.projectId);
+      const uiScreens = SiteService.toUIScreens(remoteScreens);
+
+      const siteManifest = new SiteManifest(options.projectId);
+      const saved = await siteManifest.load();
+      for (const screen of uiScreens) {
+        const state = saved.get(screen.id);
+        if (state?.status) screen.status = state.status;
+        if (state?.route) screen.route = state.route;
+      }
+
+      const included = uiScreens.filter(s => s.status === 'included');
+      const exportData = {
+        projectId: options.projectId,
+        routes: included.map(s => ({
+          screenId: s.id,
+          route: s.route,
+        })),
+      };
+      console.log(JSON.stringify(exportData, null, 2));
+      return;
+    }
 
     let resultConfig: SiteConfig | null = null;
     let resultHtml: Map<string, string> | undefined;

--- a/src/commands/site/ui/SiteBuilder.tsx
+++ b/src/commands/site/ui/SiteBuilder.tsx
@@ -250,6 +250,18 @@ export const SiteBuilder: React.FC<SiteBuilderProps> = ({ projectId, client, onE
         exit();
     }
 
+    if (input === 'e') {
+        const included = screens.filter(s => s.status === 'included');
+        const exportData = {
+            projectId,
+            routes: included.map(s => ({
+                screenId: s.id,
+                route: s.route,
+            })),
+        };
+        process.stdout.write(JSON.stringify(exportData, null, 2) + '\n');
+    }
+
     if (key.escape) {
         onExit(null);
         exit();
@@ -351,7 +363,7 @@ export const SiteBuilder: React.FC<SiteBuilderProps> = ({ projectId, client, onE
         <Text dimColor>
             {viewMode === 'discarded'
                 ? '[↑↓] Navigate [x] Undiscard [d] Back to All [Esc] Quit'
-                : `[↑↓] Navigate [Space] Toggle [Enter] Edit Route [x] Discard [d] View Discarded [t] Filter [f] Follow: ${followMode ? 'ON' : 'OFF'} [g] Generate [Esc] Quit`
+                : `[↑↓] Navigate [Space] Toggle [Enter] Edit Route [x] Discard [d] View Discarded [t] Filter [f] Follow: ${followMode ? 'ON' : 'OFF'} [g] Generate [e] Export [Esc] Quit`
             }
         </Text>
       </Box>


### PR DESCRIPTION
Add two ways to export the computed screen-to-route config in the shape that build_site expects: a --export CLI flag that prints JSON to stdout without launching the interactive UI, and an `e` key in the interactive builder for a snapshot export while staying open.