### PR TITLE
fix: suppress dotenv output to fix MCP STDIO protocol

### DIFF
--- a/src/commands/doctor/handler.ts
+++ b/src/commands/doctor/handler.ts
@@ -42,7 +42,7 @@ export class DoctorHandler implements DoctorCommand {
   }
 
   async execute(input: DoctorInput): Promise<DoctorResult> {
-    dotenv.config();
+    dotenv.config({ quiet: true });
     const apiKey = process.env.STITCH_API_KEY;
 
     const context: DoctorContext = {

--- a/src/services/proxy/handler.ts
+++ b/src/services/proxy/handler.ts
@@ -161,7 +161,7 @@ export class ProxyHandler implements ProxyService {
     }
 
     try {
-      dotenv.config();
+      dotenv.config({ quiet: true });
       const apiKey = process.env.STITCH_API_KEY;
       let authConfig: AuthConfig;
 


### PR DESCRIPTION
Fixes MCP initialization error by suppressing dotenv debug output.

**Problem:** dotenv outputs debug message to stdout, breaking MCP JSON protocol

<img width="669" height="274" alt="Screenshot 2026-02-14 at 21 54 14" src="https://github.com/user-attachments/assets/97ce59ea-4d01-4d52-b180-bdc3d989bb69" />

**Fix:** Add `{ quiet: true }` to `dotenv.config()` in proxy and doctor handlers

**Testing:** Verified with Antigravity MCP client - initialization now succeeds  

**Result:** Clean JSON-only stdout, MCP clients can now parse responses correctly
