### PR TITLE
deploy: add GitHub Pages workflow and base path support

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -1,0 +1,55 @@
+name: Deploy Docs Site
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'site/**'
+      - 'docs/**'
+      - '.github/workflows/deploy-site.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        working-directory: site
+        run: npm install
+
+      - name: Build site
+        working-directory: site
+        run: npm run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -6,12 +6,16 @@ import tailwindcss from '@tailwindcss/vite';
 import { remarkRewriteLinks } from './src/lib/remark-rewrite-links';
 import { rehypeTuiFrames } from './src/lib/rehype-tui-frames';
 
+const base = '/stitch-mcp';
+
 // https://astro.build/config
 export default defineConfig({
+  site: 'https://davideast.github.io',
+  base,
   integrations: [react()],
 
   markdown: {
-    remarkPlugins: [remarkRewriteLinks],
+    remarkPlugins: [[remarkRewriteLinks, { base }]],
     rehypePlugins: [rehypeTuiFrames],
     shikiConfig: {
       theme: 'css-variables',

--- a/site/src/components/DocsSidebar.tsx
+++ b/site/src/components/DocsSidebar.tsx
@@ -13,6 +13,7 @@ interface SidebarSection {
 interface DocsSidebarProps {
   sections: SidebarSection[];
   activePath?: string;
+  basePath?: string;
 }
 
 const GitHubIcon = () => (
@@ -41,11 +42,11 @@ const NAV_LABELS: Record<string, string> = {
   "Preview Designs": "Previewing",
 };
 
-export function DocsSidebar({ sections, activePath }: DocsSidebarProps) {
+export function DocsSidebar({ sections, activePath, basePath = "" }: DocsSidebarProps) {
   return (
     <aside className="fixed top-0 left-0 w-[200px] h-screen bg-bg border-r border-subtle-white flex flex-col p-6 z-50">
       <div className="mb-10">
-        <a href="/" className="text-[13px] text-white font-mono">
+        <a href={`${basePath}/`} className="text-[13px] text-white font-mono">
           stitch-mcp
         </a>
       </div>

--- a/site/src/layouts/DocsLayout.astro
+++ b/site/src/layouts/DocsLayout.astro
@@ -16,9 +16,10 @@ interface Props {
 }
 
 const { title, categoryDisplay, description, activePath, sections, prev, next } = Astro.props;
+const basePath = import.meta.env.BASE_URL.replace(/\/$/, "");
 ---
 <BaseLayout title={`${title} — stitch-mcp`}>
-  <DocsSidebar sections={sections} activePath={activePath} />
+  <DocsSidebar sections={sections} activePath={activePath} basePath={basePath} />
   <main class="ml-[200px]">
     <div class="max-w-[700px] mx-auto px-6 pt-24 pb-24">
       <PageHeader category={categoryDisplay} title={title}>

--- a/site/src/lib/remark-rewrite-links.ts
+++ b/site/src/lib/remark-rewrite-links.ts
@@ -1,17 +1,22 @@
 import { visit } from "unist-util-visit";
 import type { Root, Link } from "mdast";
 
+interface Options {
+  base?: string;
+}
+
 /**
  * Remark plugin that rewrites relative `.md` links to root paths.
- * e.g. `[Setup](setup.md)` → `[Setup](/setup)`
- *      `[Setup](setup.md#section)` → `[Setup](/setup#section)`
+ * e.g. `[Setup](setup.md)` → `[Setup](/stitch-mcp/setup)`
+ *      `[Setup](setup.md#section)` → `[Setup](/stitch-mcp/setup#section)`
  */
-export function remarkRewriteLinks() {
+export function remarkRewriteLinks(options: Options = {}) {
+  const base = (options.base ?? "").replace(/\/$/, "");
   return (tree: Root) => {
     visit(tree, "link", (node: Link) => {
       const url = node.url;
       if (!url.startsWith("http") && url.includes(".md")) {
-        node.url = "/" + url.replace(/\.md(#|$)/, "$1");
+        node.url = base + "/" + url.replace(/\.md(#|$)/, "$1");
       }
     });
   };

--- a/site/src/pages/[...slug].astro
+++ b/site/src/pages/[...slug].astro
@@ -31,6 +31,8 @@ const { Content } = await render(entry);
 const allDocs = await getCollection("docs");
 
 // Build sidebar sections (exclude overview — it's the landing page)
+const base = import.meta.env.BASE_URL.replace(/\/$/, "");
+
 const sections = CATEGORY_ORDER.map((cat) => {
   const pages = allDocs
     .filter((d) => d.data.category === cat)
@@ -39,7 +41,7 @@ const sections = CATEGORY_ORDER.map((cat) => {
     category: CATEGORY_LABELS[cat],
     links: pages.map((p) => ({
       label: p.data.title,
-      href: `/${p.id}`,
+      href: `${base}/${p.id}`,
     })),
   };
 }).filter((s) => s.links.length > 0);
@@ -61,7 +63,7 @@ const nextEntry =
   currentIndex < navOrder.length - 1 ? navOrder[currentIndex + 1] : undefined;
 
 function entryHref(e: (typeof allDocs)[number]) {
-  return e.id === "index" ? "/" : `/${e.id}`;
+  return e.id === "index" ? `${base}/` : `${base}/${e.id}`;
 }
 
 const activePath = entryHref(entry);


### PR DESCRIPTION
Add deploy-site.yml workflow that builds the Astro site and deploys to GitHub Pages on pushes to main (scoped to site/ and docs/ changes).

Prefix all internal links with the /stitch-mcp base path so the site works correctly under davideast.github.io/stitch-mcp/.