### PR TITLE
🔒 Fix: Add Security Headers to HTML Preview Server

### DIFF
--- a/src/ui/serve-behaviors/security.test.ts
+++ b/src/ui/serve-behaviors/security.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import { serveHtmlInMemory } from './server';
+import { get } from 'node:http';
+
+describe('serveHtmlInMemory Security', () => {
+  let stopServer: (() => void) | undefined;
+
+  afterEach(() => {
+    if (stopServer) {
+      stopServer();
+      stopServer = undefined;
+    }
+  });
+
+  it('serves html content with security headers', async () => {
+    const html = '<h1>Hello World</h1>';
+    const instance = await serveHtmlInMemory(html, { openBrowser: false });
+    stopServer = instance.stop;
+
+    const { headers } = await new Promise<{ headers: any }>((resolve, reject) => {
+      get(instance.url, (res) => {
+        resolve({ headers: res.headers });
+        res.resume(); // consume the stream
+      }).on('error', reject);
+    });
+
+    // Check for CSP headers
+    expect(headers['content-security-policy']).toBeDefined();
+    // Default CSP should be reasonably strict but functional for previews
+    expect(headers['content-security-policy']).toContain("default-src 'self'");
+
+    // Check for X-Content-Type-Options
+    expect(headers['x-content-type-options']).toBe('nosniff');
+
+    // Check for Referrer-Policy
+    expect(headers['referrer-policy']).toBe('no-referrer');
+  });
+});

--- a/src/ui/serve-behaviors/server.ts
+++ b/src/ui/serve-behaviors/server.ts
@@ -18,7 +18,12 @@ export async function serveHtmlInMemory(
 
   return new Promise((resolve, reject) => {
     const server: Server = createServer((req, res) => {
-      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      res.writeHead(200, {
+        'Content-Type': 'text/html; charset=utf-8',
+        'Content-Security-Policy': "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: https:;",
+        'X-Content-Type-Options': 'nosniff',
+        'Referrer-Policy': 'no-referrer',
+      });
       res.end(html);
     });
 


### PR DESCRIPTION
This PR addresses a security vulnerability where the local HTML preview server was serving content without security headers, potentially exposing the user to XSS or other attacks if the previewed content was malicious.

Changes:
- Modified `src/ui/serve-behaviors/server.ts` to include:
    - `Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data: https:;`
    - `X-Content-Type-Options: nosniff`
    - `Referrer-Policy: no-referrer`
- Added a regression test `src/ui/serve-behaviors/security.test.ts` to ensure these headers are always present.

The CSP is configured to allow `https:` (for CDNs) and `unsafe-inline`/`unsafe-eval` (common in development/single-file HTMLs) while blocking insecure HTTP resources and restricting other origins.


---
*PR created automatically by Jules for task [4153042678248973154](https://jules.google.com/task/4153042678248973154) started by @davideast*