### PR TITLE
🧹 cleanup: remove unused ProjectSchema import in GcloudHandler

### DIFF
--- a/src/services/gcloud/handler.ts
+++ b/src/services/gcloud/handler.ts
@@ -11,7 +11,6 @@ import {
   type AuthResult,
   type ProjectListResult,
   type ProjectSetResult,
-  type ProjectSchema,
 } from './spec.js';
 import { detectPlatform, getGcloudSdkPath, getGcloudConfigPath, getStitchDir } from '../../platform/detector.js';
 import { execCommand, commandExists } from '../../platform/shell.js';


### PR DESCRIPTION
Removed the unused `ProjectSchema` import from `src/services/gcloud/handler.ts`. This is a code health improvement that improves maintainability and readability by removing dead code. Verification was performed via grep and visual inspection, and a positive code review was received.

---
*PR created automatically by Jules for task [915638868119197650](https://jules.google.com/task/915638868119197650) started by @davideast*