### PR TITLE
feat: auto-discover CLI commands using import.meta.glob

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@_davideast/stitch-mcp",
@@ -42,6 +41,7 @@
         "react-devtools-core": "^6.1.2",
         "signal-exit": "^4.1.0",
         "typescript": "^5.7.3",
+        "vite-node": "^5.3.0",
         "vitest": "^4.0.18",
       },
     },
@@ -355,6 +355,8 @@
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
+    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
@@ -489,7 +491,7 @@
 
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
 
-    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+    "es-module-lexer": ["es-module-lexer@2.0.0", "", {}, "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw=="],
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
@@ -1059,6 +1061,8 @@
 
     "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 
+    "vite-node": ["vite-node@5.3.0", "", { "dependencies": { "cac": "^6.7.14", "es-module-lexer": "^2.0.0", "obug": "^2.1.1", "pathe": "^2.0.3", "vite": "^7.3.1" }, "bin": { "vite-node": "dist/cli.mjs" } }, "sha512-8f20COPYJujc3OKPX6OuyBy3ZIv2det4eRRU4GY1y2MjbeGSUmPjedxg1b72KnTagCofwvZ65ThzjxDW2AtQFQ=="],
+
     "vitest": ["vitest@4.0.18", "", { "dependencies": { "@vitest/expect": "4.0.18", "@vitest/mocker": "4.0.18", "@vitest/pretty-format": "4.0.18", "@vitest/runner": "4.0.18", "@vitest/snapshot": "4.0.18", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.18", "@vitest/browser-preview": "4.0.18", "@vitest/browser-webdriverio": "4.0.18", "@vitest/ui": "4.0.18", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ=="],
 
     "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
@@ -1298,6 +1302,8 @@
     "terminal-link/ansi-escapes": ["ansi-escapes@5.0.0", "", { "dependencies": { "type-fest": "^1.0.2" } }, "sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA=="],
 
     "update-notifier/is-in-ci": ["is-in-ci@1.0.0", "", { "bin": { "is-in-ci": "cli.js" } }, "sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg=="],
+
+    "vitest/es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
 
     "whatwg-encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "README.md"
   ],
   "scripts": {
-    "build": "bun build src/index.ts src/cli.ts --outdir=dist --target=node --format=esm --external lightningcss --external vite --external @astrojs/compiler && tsc -p tsconfig.build.json && bun scripts/generate-bin.ts",
-    "dev": "bun run src/cli.ts",
+    "build": "vite build && tsc -p tsconfig.build.json && bun scripts/generate-bin.ts",
+    "dev": "vite-node src/cli.ts",
     "test": "bun test --preload ./tests/setup.ts",
     "prepublishOnly": "bun run build",
     "verify-pack": "bun scripts/verify-pack.ts",
@@ -71,6 +71,7 @@
     "react-devtools-core": "^6.1.2",
     "signal-exit": "^4.1.0",
     "typescript": "^5.7.3",
+    "vite-node": "^5.3.0",
     "vitest": "^4.0.18"
   },
   "engines": {

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -1,25 +1,9 @@
-// This file is auto-generated. Do not edit manually.
+/// <reference types="vite/client" />
 import { type CommandDefinition } from '../framework/CommandDefinition.js';
-import { command as view } from './view/command.js';
-import { command as logout } from './logout/command.js';
-import { command as serve } from './serve/command.js';
-import { command as screens } from './screens/command.js';
-import { command as site } from './site/command.js';
-import { command as init } from './init/command.js';
-import { command as doctor } from './doctor/command.js';
-import { command as tool } from './tool/command.js';
-import { command as proxy } from './proxy/command.js';
-import { command as snapshot } from './snapshot/command.js';
 
-export const commands: CommandDefinition[] = [
-  view,
-  logout,
-  serve,
-  screens,
-  site,
-  init,
-  doctor,
-  tool,
-  proxy,
-  snapshot
-];
+// Auto-discover commands using import.meta.glob
+const modules = import.meta.glob('./*/command.ts', { eager: true }) as Record<string, { command: CommandDefinition }>;
+
+export const commands: CommandDefinition[] = Object.values(modules)
+  .map((mod) => mod.command)
+  .sort((a, b) => a.name.localeCompare(b.name));

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig } from 'vite';
+import { builtinModules } from 'module';
+
+export default defineConfig({
+  build: {
+    target: 'node18',
+    outDir: 'dist',
+    lib: {
+      entry: {
+        index: 'src/index.ts',
+        cli: 'src/cli.ts',
+      },
+      formats: ['es'],
+    },
+    rollupOptions: {
+      // Match bun build behavior: bundle everything except specific externals and node builtins
+      external: [
+        ...builtinModules,
+        ...builtinModules.map(m => `node:${m}`),
+        'lightningcss',
+        'vite',
+        '@astrojs/compiler',
+      ],
+      output: {
+        entryFileNames: '[name].js',
+        chunkFileNames: 'chunks/[name]-[hash].js',
+      },
+    },
+    minify: false,
+    emptyOutDir: true,
+  },
+});


### PR DESCRIPTION
This change refactors the CLI command registration mechanism to use `import.meta.glob` for auto-discovery. This eliminates the need for manual updates to `src/commands/registry.ts` when adding new commands, thereby reducing merge conflicts in parallel development workflows. To support `import.meta.glob` in a Node.js environment, the build system was migrated from `bun build` to `vite build` (configured for Node library output), and the development script was updated to use `vite-node`. Existing functionality and tests were verified.

---
*PR created automatically by Jules for task [1462153631140050673](https://jules.google.com/task/1462153631140050673) started by @davideast*