### PR TITLE
Refactor: Enforce strict input validation for init, doctor, and logout commands

### DIFF
--- a/PREVENT_CONFLICTS.md
+++ b/PREVENT_CONFLICTS.md
@@ -40,8 +40,10 @@ Break down "God Classes" into focused, domain-specific services. Use composition
     -   `StitchApiService`: Handle API enablement.
     -   `StitchConnectionService`: Handle connectivity tests.
 
-### B. Enforce Strict Input Validation (Zod)
+### B. Enforce Strict Input Validation (Zod) (Partially Completed: 2025-02-18)
 Replace `any` in `CommandDefinition` with Zod schemas. This allows automatic type inference and validation.
+
+**Implemented for:** `init`, `doctor`, `logout`.
 
 1.  **Define Schema:**
     ```typescript

--- a/src/commands/doctor/command.ts
+++ b/src/commands/doctor/command.ts
@@ -1,7 +1,8 @@
 import { type CommandDefinition } from '../../framework/CommandDefinition.js';
 import { theme, icons } from '../../ui/theme.js';
+import { DoctorOptionsSchema, type DoctorOptions } from './spec.js';
 
-export const command: CommandDefinition = {
+export const command: CommandDefinition<any, DoctorOptions> = {
   name: 'doctor',
   description: 'Verify configuration health',
   options: [
@@ -9,10 +10,11 @@ export const command: CommandDefinition = {
   ],
   action: async (_args, options) => {
     try {
+      const parsedOptions = DoctorOptionsSchema.parse(options);
       const { DoctorHandler } = await import('./handler.js');
       const handler = new DoctorHandler();
       const result = await handler.execute({
-        verbose: options.verbose,
+        verbose: parsedOptions.verbose,
       });
 
       if (!result.success) {

--- a/src/commands/doctor/spec.ts
+++ b/src/commands/doctor/spec.ts
@@ -4,6 +4,11 @@ import { z } from 'zod';
 // INPUT SCHEMAS
 // ============================================================================
 
+export const DoctorOptionsSchema = z.object({
+  verbose: z.boolean().default(false),
+});
+export type DoctorOptions = z.infer<typeof DoctorOptionsSchema>;
+
 export const DoctorInputSchema = z.object({
   verbose: z.boolean().default(false),
 });

--- a/src/commands/init/command.ts
+++ b/src/commands/init/command.ts
@@ -1,7 +1,8 @@
 import { type CommandDefinition } from '../../framework/CommandDefinition.js';
 import { theme, icons } from '../../ui/theme.js';
+import { InitOptionsSchema, type InitOptions } from './spec.js';
 
-export const command: CommandDefinition = {
+export const command: CommandDefinition<any, InitOptions> = {
   name: 'init',
   description: 'Initialize authentication and MCP configuration',
   options: [
@@ -13,14 +14,15 @@ export const command: CommandDefinition = {
   ],
   action: async (_args, options) => {
     try {
+      const parsedOptions = InitOptionsSchema.parse(options);
       const { InitHandler } = await import('./handler.js');
       const handler = new InitHandler();
       const result = await handler.execute({
-        local: options.local,
-        defaults: options.defaults,
-        autoVerify: options.yes,
-        client: options.client,
-        transport: options.transport,
+        local: parsedOptions.local,
+        defaults: parsedOptions.defaults,
+        autoVerify: parsedOptions.yes,
+        client: parsedOptions.client,
+        transport: parsedOptions.transport,
       });
 
       if (!result.success) {

--- a/src/commands/init/spec.ts
+++ b/src/commands/init/spec.ts
@@ -4,6 +4,15 @@ import { z } from 'zod';
 // INPUT SCHEMAS
 // ============================================================================
 
+export const InitOptionsSchema = z.object({
+  local: z.boolean().default(false),
+  yes: z.boolean().default(false),
+  defaults: z.boolean().default(false),
+  client: z.string().optional(),
+  transport: z.string().optional(),
+});
+export type InitOptions = z.infer<typeof InitOptionsSchema>;
+
 export const InitInputSchema = z.object({
   local: z.boolean().default(false),
   defaults: z.boolean().default(false),

--- a/src/commands/logout/command.ts
+++ b/src/commands/logout/command.ts
@@ -1,7 +1,8 @@
 import { type CommandDefinition } from '../../framework/CommandDefinition.js';
 import { theme, icons } from '../../ui/theme.js';
+import { LogoutOptionsSchema, type LogoutOptions } from './spec.js';
 
-export const command: CommandDefinition = {
+export const command: CommandDefinition<any, LogoutOptions> = {
   name: 'logout',
   description: 'Log out of Google Cloud and revoke credentials',
   options: [
@@ -10,11 +11,12 @@ export const command: CommandDefinition = {
   ],
   action: async (_args, options) => {
     try {
+      const parsedOptions = LogoutOptionsSchema.parse(options);
       const { LogoutHandler } = await import('./handler.js');
       const handler = new LogoutHandler();
       const result = await handler.execute({
-        force: options.force,
-        clearConfig: options.clearConfig,
+        force: parsedOptions.force,
+        clearConfig: parsedOptions.clearConfig,
       });
 
       if (!result.success) {

--- a/src/commands/logout/spec.ts
+++ b/src/commands/logout/spec.ts
@@ -4,6 +4,12 @@ import { z } from 'zod';
 // INPUT SCHEMAS
 // ============================================================================
 
+export const LogoutOptionsSchema = z.object({
+  force: z.boolean().default(false),
+  clearConfig: z.boolean().default(false),
+});
+export type LogoutOptions = z.infer<typeof LogoutOptionsSchema>;
+
 export const LogoutInputSchema = z.object({
   force: z.boolean().default(false),
   clearConfig: z.boolean().default(false),


### PR DESCRIPTION
This PR implements strict input validation for the `init`, `doctor`, and `logout` commands as part of the "Prevent Conflicts" initiative. It introduces Zod schemas mirroring the CLI options in `spec.ts` and uses them to validate inputs in `command.ts` actions. This improves type safety and robustness of the CLI. The changes were verified with existing tests.

---
*PR created automatically by Jules for task [2797057257062411009](https://jules.google.com/task/2797057257062411009) started by @davideast*