### PR TITLE
Enforce Strict Input Validation (Zod) for proxy, tool, and view commands

### DIFF
--- a/PREVENT_CONFLICTS.md
+++ b/PREVENT_CONFLICTS.md
@@ -40,10 +40,10 @@ Break down "God Classes" into focused, domain-specific services. Use composition
     -   `StitchApiService`: Handle API enablement.
     -   `StitchConnectionService`: Handle connectivity tests.
 
-### B. Enforce Strict Input Validation (Zod) (Partially Completed: 2025-02-18)
+### B. Enforce Strict Input Validation (Zod) (Partially Completed: 2025-02-22)
 Replace `any` in `CommandDefinition` with Zod schemas. This allows automatic type inference and validation.
 
-**Implemented for:** `init`, `doctor`, `logout`.
+**Implemented for:** `init`, `doctor`, `logout`, `proxy`, `tool`, `view`.
 
 1.  **Define Schema:**
     ```typescript

--- a/src/commands/proxy/command.ts
+++ b/src/commands/proxy/command.ts
@@ -1,7 +1,8 @@
 import { type CommandDefinition } from '../../framework/CommandDefinition.js';
 import { theme, icons } from '../../ui/theme.js';
+import { ProxyOptionsSchema, type ProxyOptions } from './spec.js';
 
-export const command: CommandDefinition = {
+export const command: CommandDefinition<any, ProxyOptions> = {
   name: 'proxy',
   description: 'Start the Stitch MCP proxy server',
   options: [
@@ -11,13 +12,14 @@ export const command: CommandDefinition = {
   ],
   action: async (_args, options) => {
     try {
+      const parsedOptions = ProxyOptionsSchema.parse(options);
       const { ProxyCommandHandler } = await import('./handler.js');
       const handler = new ProxyCommandHandler();
 
       const result = await handler.execute({
-        transport: options.transport as 'stdio' | 'sse',
-        port: options.port,
-        debug: options.debug,
+        transport: parsedOptions.transport,
+        port: parsedOptions.port,
+        debug: parsedOptions.debug,
       });
 
       if (!result.success) {

--- a/src/commands/proxy/spec.ts
+++ b/src/commands/proxy/spec.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const ProxyOptionsSchema = z.object({
+  transport: z.enum(['stdio', 'sse']).default('stdio'),
+  port: z.number().optional(),
+  debug: z.boolean().default(false),
+});
+
+export type ProxyOptions = z.infer<typeof ProxyOptionsSchema>;

--- a/src/commands/tool/command.ts
+++ b/src/commands/tool/command.ts
@@ -1,7 +1,8 @@
 import { type CommandDefinition } from '../../framework/CommandDefinition.js';
 import { theme, icons } from '../../ui/theme.js';
+import { ToolOptionsSchema, type ToolOptions } from './spec.js';
 
-export const command: CommandDefinition = {
+export const command: CommandDefinition<string | undefined, ToolOptions> = {
   name: 'tool',
   arguments: '[toolName]',
   description: 'Invoke MCP tools directly',
@@ -13,14 +14,15 @@ export const command: CommandDefinition = {
   ],
   action: async (toolName, options) => {
     try {
+      const parsedOptions = ToolOptionsSchema.parse(options);
       const { ToolCommandHandler } = await import('./handler.js');
       const handler = new ToolCommandHandler();
       const result = await handler.execute({
         toolName,
-        showSchema: options.schema,
-        data: options.data,
-        dataFile: options.dataFile,
-        output: options.output,
+        showSchema: parsedOptions.schema,
+        data: parsedOptions.data,
+        dataFile: parsedOptions.dataFile,
+        output: parsedOptions.output,
       });
 
       if (!result.success) {
@@ -33,9 +35,9 @@ export const command: CommandDefinition = {
         process.exit(1);
       }
 
-      if (options.output === 'json') {
+      if (parsedOptions.output === 'json') {
         console.log(JSON.stringify(result.data));
-      } else if (options.output === 'raw') {
+      } else if (parsedOptions.output === 'raw') {
         console.log(result.data);
       } else {
         console.log(JSON.stringify(result.data, null, 2));

--- a/src/commands/tool/spec.ts
+++ b/src/commands/tool/spec.ts
@@ -30,3 +30,13 @@ export interface ToolCommandResult {
 export interface VirtualTool extends ToolInfo {
   execute: (client: StitchMCPClient, args: any) => Promise<any>;
 }
+
+// Added for CLI validation
+export const ToolOptionsSchema = z.object({
+  schema: z.boolean().default(false),
+  data: z.string().optional(),
+  dataFile: z.string().optional(),
+  output: z.enum(['json', 'pretty', 'raw']).default('pretty'),
+});
+
+export type ToolOptions = z.infer<typeof ToolOptionsSchema>;

--- a/src/commands/view/command.ts
+++ b/src/commands/view/command.ts
@@ -1,7 +1,8 @@
 import { type CommandDefinition } from '../../framework/CommandDefinition.js';
 import { theme, icons } from '../../ui/theme.js';
+import { ViewOptionsSchema, type ViewOptions } from './spec.js';
 
-export const command: CommandDefinition = {
+export const command: CommandDefinition<any, ViewOptions> = {
   name: 'view',
   description: 'Interactively view Stitch resources',
   options: [
@@ -14,9 +15,10 @@ export const command: CommandDefinition = {
   ],
   action: async (_args, options) => {
     try {
+      const parsedOptions = ViewOptionsSchema.parse(options);
       const { ViewCommandHandler } = await import('./handler.js');
       const handler = new ViewCommandHandler();
-      await handler.execute(options);
+      await handler.execute(parsedOptions);
     } catch (error) {
       console.error(theme.red(`\n${icons.error} Unexpected error:`), error);
       process.exit(1);

--- a/src/commands/view/spec.ts
+++ b/src/commands/view/spec.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+export const ViewOptionsSchema = z.object({
+  projects: z.boolean().default(false),
+  name: z.string().optional(),
+  sourceScreen: z.string().optional(),
+  project: z.string().optional(),
+  screen: z.string().optional(),
+  serve: z.boolean().default(false),
+});
+
+export type ViewOptions = z.infer<typeof ViewOptionsSchema>;


### PR DESCRIPTION
This PR implements strict input validation using Zod for the `proxy`, `tool`, and `view` commands, as requested in `PREVENT_CONFLICTS.md`.

It creates corresponding `spec.ts` files for each command, defining Zod schemas for CLI options. The command handlers are updated to parse options using these schemas, ensuring type safety and validation before execution.

Specific changes:
- `src/commands/proxy/spec.ts`: Added `ProxyOptionsSchema`.
- `src/commands/tool/spec.ts`: Added `ToolOptionsSchema` and preserved existing types `ToolCommandInput`, `ToolInfo`, `VirtualTool`, etc.
- `src/commands/view/spec.ts`: Added `ViewOptionsSchema`.
- `src/commands/*/command.ts`: Updated to use `Schema.parse(options)` and handle validation errors.
- `PREVENT_CONFLICTS.md`: Updated status of "Enforce Strict Input Validation (Zod)" task.


---
*PR created automatically by Jules for task [1702996088306191168](https://jules.google.com/task/1702996088306191168) started by @davideast*