### PR TITLE
Enforce Zod input validation for remaining CLI commands

### DIFF
--- a/PREVENT_CONFLICTS.md
+++ b/PREVENT_CONFLICTS.md
@@ -40,10 +40,10 @@ Break down "God Classes" into focused, domain-specific services. Use composition
     -   `StitchApiService`: Handle API enablement.
     -   `StitchConnectionService`: Handle connectivity tests.
 
-### B. Enforce Strict Input Validation (Zod) (Partially Completed: 2025-02-22)
+### B. Enforce Strict Input Validation (Zod) (Completed: 2025-02-23)
 Replace `any` in `CommandDefinition` with Zod schemas. This allows automatic type inference and validation.
 
-**Implemented for:** `init`, `doctor`, `logout`, `proxy`, `tool`, `view`.
+**Implemented for:** `init`, `doctor`, `logout`, `proxy`, `tool`, `view`, `serve`, `screens`, `site`, `snapshot`.
 
 1.  **Define Schema:**
     ```typescript

--- a/src/commands/screens/command.ts
+++ b/src/commands/screens/command.ts
@@ -1,7 +1,8 @@
 import { type CommandDefinition } from '../../framework/CommandDefinition.js';
 import { theme, icons } from '../../ui/theme.js';
+import { ScreensOptionsSchema, type ScreensOptions } from './spec.js';
 
-export const command: CommandDefinition = {
+export const command: CommandDefinition<any, ScreensOptions> = {
   name: 'screens',
   description: 'Explore all screens in a project',
   requiredOptions: [
@@ -9,6 +10,7 @@ export const command: CommandDefinition = {
   ],
   action: async (_args, options) => {
     try {
+      const parsedOptions = ScreensOptionsSchema.parse(options);
       const { ScreensHandler } = await import('./handler.js');
       const { ScreensView } = await import('./ScreensView.js');
       const { StitchMCPClient } = await import('../../services/mcp-client/client.js');
@@ -17,7 +19,7 @@ export const command: CommandDefinition = {
 
       const client = new StitchMCPClient();
       const handler = new ScreensHandler(client);
-      const result = await handler.execute(options.project);
+      const result = await handler.execute(parsedOptions.project);
 
       if (!result.success) {
         console.error(theme.red(`\n${icons.error} Failed: ${result.error}`));

--- a/src/commands/screens/spec.ts
+++ b/src/commands/screens/spec.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const ScreensOptionsSchema = z.object({
+  project: z.string(),
+});
+
+export type ScreensOptions = z.infer<typeof ScreensOptionsSchema>;

--- a/src/commands/serve/command.ts
+++ b/src/commands/serve/command.ts
@@ -1,7 +1,8 @@
 import { type CommandDefinition } from '../../framework/CommandDefinition.js';
 import { theme, icons } from '../../ui/theme.js';
+import { ServeOptionsSchema, type ServeOptions } from './spec.js';
 
-export const command: CommandDefinition = {
+export const command: CommandDefinition<any, ServeOptions> = {
   name: 'serve',
   description: 'Serve project HTML screens via local web server',
   requiredOptions: [
@@ -9,6 +10,7 @@ export const command: CommandDefinition = {
   ],
   action: async (_args, options) => {
     try {
+      const parsedOptions = ServeOptionsSchema.parse(options);
       const { ServeHandler } = await import('./handler.js');
       const { ServeView } = await import('./ServeView.js');
       const { StitchMCPClient } = await import('../../services/mcp-client/client.js');
@@ -17,7 +19,7 @@ export const command: CommandDefinition = {
 
       const client = new StitchMCPClient();
       const handler = new ServeHandler(client);
-      const result = await handler.execute(options.project);
+      const result = await handler.execute(parsedOptions.project);
 
       if (!result.success) {
         console.error(theme.red(`\n${icons.error} Failed: ${result.error}`));

--- a/src/commands/serve/spec.ts
+++ b/src/commands/serve/spec.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const ServeOptionsSchema = z.object({
+  project: z.string(),
+});
+
+export type ServeOptions = z.infer<typeof ServeOptionsSchema>;

--- a/src/commands/site/command.ts
+++ b/src/commands/site/command.ts
@@ -1,7 +1,8 @@
 import { type CommandDefinition } from '../../framework/CommandDefinition.js';
 import { theme, icons } from '../../ui/theme.js';
+import { SiteOptionsSchema, type SiteOptions } from './spec.js';
 
-export const command: CommandDefinition = {
+export const command: CommandDefinition<any, SiteOptions> = {
   name: 'site',
   description: 'Build a structured site from Stitch screens',
   requiredOptions: [
@@ -13,12 +14,13 @@ export const command: CommandDefinition = {
   ],
   action: async (_args, options) => {
     try {
+      const parsedOptions = SiteOptionsSchema.parse(options);
       const { SiteCommandHandler } = await import('./index.js');
       const handler = new SiteCommandHandler();
       await handler.execute({
-          projectId: options.project,
-          outputDir: options.output,
-          export: options.export
+          projectId: parsedOptions.project,
+          outputDir: parsedOptions.output,
+          export: parsedOptions.export
       });
       process.exit(0);
     } catch (error) {

--- a/src/commands/site/spec.ts
+++ b/src/commands/site/spec.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const SiteOptionsSchema = z.object({
+  project: z.string(),
+  output: z.string().default('.'),
+  export: z.boolean().default(false),
+});
+
+export type SiteOptions = z.infer<typeof SiteOptionsSchema>;

--- a/src/commands/snapshot/command.ts
+++ b/src/commands/snapshot/command.ts
@@ -1,7 +1,8 @@
 import { type CommandDefinition } from '../../framework/CommandDefinition.js';
 import { theme } from '../../ui/theme.js';
+import { SnapshotInputSchema, type SnapshotInput } from './spec.js';
 
-export const command: CommandDefinition = {
+export const command: CommandDefinition<any, SnapshotInput> = {
   name: 'snapshot',
   description: 'Create a UI snapshot given a data state',
   options: [
@@ -11,12 +12,13 @@ export const command: CommandDefinition = {
   ],
   action: async (_args, options) => {
     try {
+      const parsedOptions = SnapshotInputSchema.parse(options);
       const { SnapshotHandler } = await import('./handler.js');
       const handler = new SnapshotHandler();
       const result = await handler.execute({
-        command: options.command,
-        data: options.data,
-        schema: options.schema,
+        command: parsedOptions.command,
+        data: parsedOptions.data,
+        schema: parsedOptions.schema,
       });
 
       if (!result.success) {


### PR DESCRIPTION
This PR completes the "Enforce Strict Input Validation (Zod)" task from `PREVENT_CONFLICTS.md`. It adds Zod schemas for CLI options in `serve`, `screens`, `site`, and `snapshot` commands, ensuring type safety and runtime validation. This aligns these commands with the pattern already established in `init`, `doctor`, etc. It also updates `PREVENT_CONFLICTS.md` to reflect the completion of this architectural goal.


---
*PR created automatically by Jules for task [18028638276617257258](https://jules.google.com/task/18028638276617257258) started by @davideast*