### PR TITLE
🧪 Add test for checkAPIEnabled exception handling

### DIFF
--- a/src/services/stitch/handler.test.ts
+++ b/src/services/stitch/handler.test.ts
@@ -265,6 +265,12 @@ describe('StitchHandler', () => {
       const result = await handler.checkIAMRole(validInput);
       expect(result).toBe(false);
     });
+
+    test('should return false when execution throws an exception', async () => {
+      mockExecCommand.mockRejectedValue(new Error('Network error'));
+      const result = await handler.checkIAMRole(validInput);
+      expect(result).toBe(false);
+    });
   });
 
   describe('checkAPIEnabled', () => {
@@ -284,6 +290,12 @@ describe('StitchHandler', () => {
 
     test('should return false on command failure', async () => {
       mockExecCommand.mockResolvedValue({ success: false, stdout: '', stderr: 'error', exitCode: 1 });
+      const result = await handler.checkAPIEnabled(validInput);
+      expect(result).toBe(false);
+    });
+
+    test('should return false when execution throws an exception', async () => {
+      mockExecCommand.mockRejectedValue(new Error('Network error'));
       const result = await handler.checkAPIEnabled(validInput);
       expect(result).toBe(false);
     });


### PR DESCRIPTION
🎯 **What:** The testing gap was that `checkAPIEnabled` and `checkIAMRole` methods in `StitchHandler` did not have tests verifying their `try-catch` exception handling capabilities when `execCommand` throws an error.
📊 **Coverage:** Added test cases for when `execCommand` rejects with an error for both `checkAPIEnabled` and `checkIAMRole`. Both methods now accurately assert that `false` is returned on execution exception.
✨ **Result:** Test suite is now more robust and verifies expected error handling behaviors for `StitchHandler` checks.

---
*PR created automatically by Jules for task [3898292076216695181](https://jules.google.com/task/3898292076216695181) started by @davideast*