### PR TITLE
🧪 [testing improvement] Add test for McpConfigHandler generateConfig

### DIFF
--- a/src/services/mcp-config/handler_apikey.test.ts
+++ b/src/services/mcp-config/handler_apikey.test.ts
@@ -62,4 +62,121 @@ describe('McpConfigHandler (API Key)', () => {
       expect(result.data.instructions).not.toContain('Authorization');
     }
   });
+
+  it('should generate Antigravity configuration with API key', async () => {
+    const input = {
+      client: 'antigravity' as const,
+      projectId: 'test-project',
+      accessToken: 'ignored',
+      transport: 'http' as const,
+      apiKey: 'test-api-key',
+    };
+
+    const result = await handler.generateConfig(input);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const config = JSON.parse(result.data.config);
+      expect(config.mcpServers.stitch.headers['X-Goog-Api-Key']).toBe('test-api-key');
+      expect(config.mcpServers.stitch.headers.Authorization).toBeUndefined();
+    }
+  });
+
+  it('should generate OpenCode HTTP configuration with API key', async () => {
+    const input = {
+      client: 'opencode' as const,
+      projectId: 'test-project',
+      accessToken: 'ignored',
+      transport: 'http' as const,
+      apiKey: 'test-api-key',
+    };
+
+    const result = await handler.generateConfig(input);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const config = JSON.parse(result.data.config);
+      expect(config.mcp.stitch.headers['X-Goog-Api-Key']).toBe('test-api-key');
+      expect(config.mcp.stitch.headers.Authorization).toBeUndefined();
+    }
+  });
+
+  it('should generate OpenCode STDIO configuration with API key', async () => {
+    const input = {
+      client: 'opencode' as const,
+      projectId: 'test-project',
+      accessToken: 'ignored',
+      transport: 'stdio' as const,
+      apiKey: 'test-api-key',
+    };
+
+    const result = await handler.generateConfig(input);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const config = JSON.parse(result.data.config);
+      expect(config.mcp.stitch.environment.STITCH_API_KEY).toBe('test-api-key');
+      expect(config.mcp.stitch.environment.STITCH_PROJECT_ID).toBeUndefined();
+    }
+  });
+
+  it('should generate Codex CLI HTTP configuration with API key', async () => {
+    const input = {
+      client: 'codex' as const,
+      projectId: 'test-project',
+      accessToken: 'ignored',
+      transport: 'http' as const,
+      apiKey: 'test-api-key',
+    };
+
+    const result = await handler.generateConfig(input);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.instructions).toContain('X-Goog-Api-Key = "test-api-key"');
+      expect(result.data.instructions).not.toContain('STITCH_ACCESS_TOKEN');
+    }
+  });
+
+  it('should generate Codex CLI STDIO configuration with API key', async () => {
+    const input = {
+      client: 'codex' as const,
+      projectId: 'test-project',
+      accessToken: 'ignored',
+      transport: 'stdio' as const,
+      apiKey: 'test-api-key',
+    };
+
+    const result = await handler.generateConfig(input);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.instructions).toContain('STITCH_API_KEY = "test-api-key"');
+      expect(result.data.instructions).not.toContain('STITCH_PROJECT_ID');
+    }
+  });
+
+  it('should generate STDIO configuration with API key for JSON-based clients', async () => {
+    const jsonBasedClients = ['cursor', 'antigravity', 'vscode'] as const;
+
+    for (const client of jsonBasedClients) {
+      const input = {
+        client,
+        projectId: 'test-project',
+        accessToken: 'ignored',
+        transport: 'stdio' as const,
+        apiKey: 'test-api-key',
+      };
+
+      const result = await handler.generateConfig(input);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const config = JSON.parse(result.data.config);
+        const serverConfig = client === 'vscode' ? config.servers.stitch : config.mcpServers.stitch;
+        expect(serverConfig.env.STITCH_API_KEY).toBe('test-api-key');
+        expect(serverConfig.env.STITCH_PROJECT_ID).toBeUndefined();
+      }
+    }
+  });
 });


### PR DESCRIPTION
🎯 **What:** Added tests for `McpConfigHandler.generateConfig` focusing on the API key authentication flow, which was previously undertested.
📊 **Coverage:** 
- `antigravity` (HTTP)
- `codex` (HTTP and STDIO)
- `opencode` (HTTP and STDIO)
- `cursor` (STDIO)
- `vscode` (STDIO)
✨ **Result:** Increased reliability of configuration generation for various MCP clients when using API keys.

---
*PR created automatically by Jules for task [4457518239837561290](https://jules.google.com/task/4457518239837561290) started by @davideast*