### PR TITLE
🧹 remove unused imports in tool command

### DIFF
--- a/src/commands/tool/command.ts
+++ b/src/commands/tool/command.ts
@@ -1,5 +1,4 @@
 import { type CommandDefinition } from '../../framework/CommandDefinition.js';
-import { theme, icons } from '../../ui/theme.js';
 import { ToolOptionsSchema, type ToolOptions } from './spec.js';
 
 export const command: CommandDefinition<string | undefined, ToolOptions> = {


### PR DESCRIPTION
This PR removes unused imports from the `tool` command definition file.

🎯 **What:** Removed `theme` and `icons` imports from `src/commands/tool/command.ts`.
💡 **Why:** These imports were not used anywhere in the file, and removing them improves maintainability and reduces clutter.
✅ **Verification:** 
- Verified with `grep` that `theme` and `icons` are not used in the file.
- Ran tests in `tests/commands/tool/`. While some environment-related failures occurred, they were unrelated to these changes.
✨ **Result:** Cleaner code in `src/commands/tool/command.ts`.

---
*PR created automatically by Jules for task [10064518064351816213](https://jules.google.com/task/10064518064351816213) started by @davideast*