### PR TITLE
🔒 fix: restrict permissions for generated .env file to owner only (0o600)

### DIFF
--- a/src/commands/init/steps/AuthModeStep.ts
+++ b/src/commands/init/steps/AuthModeStep.ts
@@ -30,8 +30,8 @@ export class AuthModeStep implements CommandStep<InitContext> {
         const envContent = `\nSTITCH_API_KEY=${inputKey}\n`;
 
         try {
-          // fs.promises.appendFile creates the file if it does not exist
-          await fs.promises.appendFile(envPath, envContent);
+          // fs.promises.writeFile with mode 0o600 creates the file with restricted permissions
+          await fs.promises.writeFile(envPath, envContent, { flag: 'a', mode: 0o600 });
 
           // Handle .gitignore
           const gitignorePath = path.join(process.cwd(), '.gitignore');


### PR DESCRIPTION
🎯 **What:** The `.env` file generated during the init step was being created with default file permissions using `fs.promises.appendFile`. This has been updated to use `fs.promises.writeFile` with `{ flag: 'a', mode: 0o600 }`.

⚠️ **Risk:** Storing sensitive information like `STITCH_API_KEY` in a `.env` file with default permissions could allow unauthorized users on the same system to read the API key, leading to potential credential compromise.

🛡️ **Solution:** The change replaces `fs.promises.appendFile` with `fs.promises.writeFile` and explicitly sets the file `mode` to `0o600`. This restricts read and write access strictly to the owner of the file. Using `flag: 'a'` ensures that existing content in the `.env` file is preserved, mirroring the previous behavior while adding the necessary security constraint.

---
*PR created automatically by Jules for task [17796100231507317380](https://jules.google.com/task/17796100231507317380) started by @davideast*