### PR TITLE
🔒 Fix command execution vulnerability in browser opening

### DIFF
--- a/src/commands/screens/ScreensView.tsx
+++ b/src/commands/screens/ScreensView.tsx
@@ -4,7 +4,7 @@ import type { StitchMCPClient } from '../../services/mcp-client/client.js';
 import { downloadText } from '../../ui/copy-behaviors/clipboard.js';
 import clipboard from 'clipboardy';
 import { StitchViteServer } from '../../lib/server/vite/StitchViteServer.js';
-import { spawn } from 'child_process';
+import { openUrl } from '../../platform/browser.js';
 
 interface Screen {
   screenId: string;
@@ -76,12 +76,7 @@ export function ScreensView({ projectId, projectTitle, screens, client }: Screen
           const fullUrl = `${url}${route}`;
 
           if (justStarted) {
-               const start = (process.platform == 'darwin'? 'open': process.platform == 'win32'? 'start': 'xdg-open');
-               if (process.platform === 'win32') {
-                   spawn('cmd', ['/c', 'start', fullUrl], { detached: true, stdio: 'ignore' }).unref();
-               } else {
-                   spawn(start, [fullUrl], { detached: true, stdio: 'ignore' }).unref();
-               }
+               openUrl(fullUrl);
           } else {
               srv.navigate(fullUrl);
           }

--- a/src/commands/serve/ServeView.tsx
+++ b/src/commands/serve/ServeView.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Box, Text, useInput, useApp } from 'ink';
 import { StitchViteServer } from '../../lib/server/vite/StitchViteServer.js';
 import { downloadText } from '../../ui/copy-behaviors/clipboard.js';
-import { spawn } from 'child_process';
+import { openUrl } from '../../platform/browser.js';
 
 interface CodeScreen {
   screenId: string;
@@ -95,7 +95,6 @@ export function ServeView({ projectId, projectTitle, screens }: ServeViewProps) 
       }
 
       if (key.return && serverUrl) {
-          const start = (process.platform == 'darwin'? 'open': process.platform == 'win32'? 'start': 'xdg-open');
           let target = serverUrl;
           if (selectedIndex > 0) {
               const screen = screens[selectedIndex - 1];
@@ -103,11 +102,7 @@ export function ServeView({ projectId, projectTitle, screens }: ServeViewProps) 
                   target = `${serverUrl}/screens/${screen.screenId}`;
               }
           }
-          if (process.platform === 'win32') {
-             spawn('cmd', ['/c', 'start', target], { detached: true, stdio: 'ignore' }).unref();
-          } else {
-             spawn(start, [target], { detached: true, stdio: 'ignore' }).unref();
-          }
+          openUrl(target);
       }
   });
 

--- a/src/commands/site/ui/SiteBuilder.tsx
+++ b/src/commands/site/ui/SiteBuilder.tsx
@@ -5,12 +5,12 @@ import TextInput from 'ink-text-input';
 import { StitchMCPClient } from '../../../services/mcp-client/client.js';
 import { SiteService } from '../../../lib/services/site/SiteService.js';
 import { StitchViteServer } from '../../../lib/server/vite/StitchViteServer.js';
+import { openUrl } from '../../../platform/browser.js';
 import { ProjectSyncer } from '../utils/ProjectSyncer.js';
 import { SiteManifest } from '../utils/SiteManifest.js';
 import { ScreenList } from './ScreenList.js';
 import { useProjectHydration } from '../hooks/useProjectHydration.js';
 import type { UIScreen, SiteConfig } from '../../../lib/services/site/types.js';
-import { spawn } from 'child_process';
 
 interface SiteBuilderProps {
   projectId: string;
@@ -210,13 +210,8 @@ export const SiteBuilder: React.FC<SiteBuilderProps> = ({ projectId, client, onE
 
     if (input === 'o') {
       if (serverUrl && activeScreenId) {
-          const start = (process.platform == 'darwin'? 'open': process.platform == 'win32'? 'start': 'xdg-open');
           const target = `${serverUrl}/_preview/${activeScreenId}`;
-          if (process.platform === 'win32') {
-             spawn('cmd', ['/c', 'start', target], { detached: true, stdio: 'ignore' }).unref();
-          } else {
-             spawn(start, [target], { detached: true, stdio: 'ignore' }).unref();
-          }
+          openUrl(target);
       }
     }
 

--- a/src/platform/browser.test.ts
+++ b/src/platform/browser.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, spyOn, beforeEach, afterEach } from 'bun:test';
+import { openUrl, validateUrl } from './browser.js';
+import * as childProcess from 'node:child_process';
+
+describe('browser', () => {
+  describe('validateUrl', () => {
+    it('accepts valid http and https URLs', () => {
+      expect(validateUrl('http://127.0.0.1:8080')).toBe('http://127.0.0.1:8080/');
+      expect(validateUrl('https://google.com')).toBe('https://google.com/');
+      expect(validateUrl('http://localhost/path?a=1&b=2')).toBe('http://localhost/path?a=1&b=2');
+    });
+
+    it('throws on invalid protocols', () => {
+      expect(() => validateUrl('file:///etc/passwd')).toThrow('Invalid protocol');
+      expect(() => validateUrl('javascript:alert(1)')).toThrow('Invalid protocol');
+    });
+
+    it('throws on malformed URLs', () => {
+      expect(() => validateUrl('not-a-url')).toThrow('Invalid URL');
+    });
+  });
+
+  describe('openUrl', () => {
+    let spawnSpy: any;
+
+    beforeEach(() => {
+      spawnSpy = spyOn(childProcess, 'spawn').mockReturnValue({
+        unref: () => {},
+      } as any);
+    });
+
+    afterEach(() => {
+      spawnSpy.mockRestore();
+    });
+
+    it('spawns the correct command on non-windows', () => {
+      if (process.platform !== 'win32') {
+        const cmd = process.platform === 'darwin' ? 'open' : 'xdg-open';
+        openUrl('http://127.0.0.1');
+        expect(spawnSpy).toHaveBeenCalledWith(cmd, ['http://127.0.0.1/'], expect.any(Object));
+      }
+    });
+
+    it('spawns the correct command on windows', () => {
+      if (process.platform === 'win32') {
+        openUrl('http://127.0.0.1');
+        expect(spawnSpy).toHaveBeenCalledWith('cmd', ['/c', 'start', '""', '"http://127.0.0.1/"'], {
+          detached: true,
+          stdio: 'ignore',
+          shell: false
+        });
+      }
+    });
+
+    it('handles URLs with ampersands correctly on windows', () => {
+      if (process.platform === 'win32') {
+        const url = 'http://localhost/path?a=1&b=2';
+        openUrl(url);
+        expect(spawnSpy).toHaveBeenCalledWith('cmd', ['/c', 'start', '""', `"${url}"`], {
+          detached: true,
+          stdio: 'ignore',
+          shell: false
+        });
+      }
+    });
+  });
+});

--- a/src/platform/browser.ts
+++ b/src/platform/browser.ts
@@ -1,0 +1,44 @@
+import { spawn } from 'node:child_process';
+
+/**
+ * Validates a URL to ensure it uses an allowed protocol (http or https).
+ */
+export function validateUrl(url: string): string {
+  try {
+    const parsedUrl = new URL(url);
+    if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+      throw new Error('Invalid protocol. Only http and https are allowed.');
+    }
+    return parsedUrl.toString();
+  } catch (error) {
+    throw new Error(`Invalid URL: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+/**
+ * Opens a URL in the system's default browser.
+ */
+export function openUrl(url: string): void {
+  const validatedUrl = validateUrl(url);
+
+  if (process.platform === 'win32') {
+    // On Windows, 'start' is a shell builtin. We use 'cmd /c' to invoke it.
+    // To prevent ampersand (&) injection, we pass the URL as a single quoted argument.
+    // Node's spawn with shell: false (default) will handle basic quoting,
+    // but 'cmd /c start' has complex parsing rules.
+    // Using '""' as the first argument to 'start' ensures the URL isn't interpreted as a window title.
+    // We wrap the URL in double quotes to prevent shell characters like '&' from being interpreted.
+    // Since validateUrl ensures no double quotes are in the string, this is safe.
+    spawn('cmd', ['/c', 'start', '""', `"${validatedUrl}"`], {
+      detached: true,
+      stdio: 'ignore',
+      shell: false,
+    }).unref();
+  } else {
+    const cmd = process.platform === 'darwin' ? 'open' : 'xdg-open';
+    spawn(cmd, [validatedUrl], {
+      detached: true,
+      stdio: 'ignore',
+    }).unref();
+  }
+}

--- a/src/ui/JsonTree.tsx
+++ b/src/ui/JsonTree.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo, useEffect, useRef } from 'react';
 import { Box, Text, useInput, useApp } from 'ink';
-import { spawn } from 'child_process';
+import { openUrl } from '../platform/browser.js';
 import { getHandler } from './copy-behaviors/registry.js';
 import type { CopyResult } from './copy-behaviors/types.js';
 import { getNavigationTarget, type NavigationResult } from './navigation-behaviors/handler.js';
@@ -234,9 +234,7 @@ export const JsonTree = ({ data, rootLabel, onNavigate, onBack }: JsonTreeProps)
       if (projectId) {
         const url = `https://stitch.withgoogle.com/projects/${projectId}`;
         // Open in browser using platform command
-        const openCmd = process.platform === 'darwin' ? 'open' :
-          process.platform === 'win32' ? 'start' : 'xdg-open';
-        spawn(openCmd, [url], { stdio: 'ignore', detached: true }).unref();
+        openUrl(url);
 
         if (feedbackTimeout.current) clearTimeout(feedbackTimeout.current);
         setFeedbackMessage(`🔗 Opened project in browser`);

--- a/src/ui/serve-behaviors/server.ts
+++ b/src/ui/serve-behaviors/server.ts
@@ -2,7 +2,7 @@
  * In-memory HTTP server using node:http for cross-runtime compatibility.
  */
 import { createServer, type Server } from 'node:http';
-import { spawn } from 'node:child_process';
+import { openUrl } from '../../platform/browser.js';
 
 export interface ServeInstance {
   url: string;
@@ -39,10 +39,7 @@ export async function serveHtmlInMemory(
       const stop = () => { clearTimeout(timer); server.close(); };
 
       if (openBrowser) {
-        const cmd = process.platform === 'darwin' ? 'open' :
-                    process.platform === 'win32' ? 'cmd' : 'xdg-open';
-        const args = process.platform === 'win32' ? ['/c', 'start', url] : [url];
-        spawn(cmd, args, { detached: true, stdio: 'ignore' }).unref();
+        openUrl(url);
       }
 
       resolve({ url, stop });


### PR DESCRIPTION
This change addresses a security vulnerability where unsanitized user input (URLs) could lead to arbitrary command execution when opening the system's browser.

The fix introduces a centralized `openUrl` utility in `src/platform/browser.ts` that validates URLs using the `URL` constructor and enforces a strict protocol allowlist (http and https only).

On Windows, where the risk of shell injection is highest due to `cmd.exe` builtins, the utility uses `shell: false` and carefully structured arguments for `cmd /c start` to ensure the URL is treated as a single argument and not as a window title or multiple commands separated by ampersands.

All occurrences of manual browser-opening logic have been refactored to use this secure utility.

---
*PR created automatically by Jules for task [9033641516995715126](https://jules.google.com/task/9033641516995715126) started by @davideast*