### PR TITLE
feat: add virtual field to list_tools output

### DIFF
--- a/src/commands/tool/spec.ts
+++ b/src/commands/tool/spec.ts
@@ -14,6 +14,7 @@ export type ToolCommandInput = z.infer<typeof ToolCommandInputSchema>;
 export interface ToolInfo {
   name: string;
   description?: string;
+  virtual?: boolean;
   inputSchema?: {
     type: string;
     properties?: Record<string, any>;

--- a/src/commands/tool/steps/ListToolsStep.ts
+++ b/src/commands/tool/steps/ListToolsStep.ts
@@ -13,7 +13,10 @@ export class ListToolsStep implements CommandStep<ToolContext> {
   async run(context: ToolContext): Promise<StepResult> {
     const result = await context.client.listTools();
     const serverTools = result.tools || [];
-    const tools = [...context.virtualTools, ...serverTools];
+    const tools = [
+      ...context.virtualTools.map(t => ({ name: t.name, description: t.description, inputSchema: t.inputSchema, virtual: true as const })),
+      ...serverTools.map(t => ({ ...t, virtual: false as const })),
+    ];
     context.result = { success: true, data: tools };
     return { success: true };
   }

--- a/src/commands/tool/steps/ShowSchemaStep.ts
+++ b/src/commands/tool/steps/ShowSchemaStep.ts
@@ -42,6 +42,7 @@ export class ShowSchemaStep implements CommandStep<ToolContext> {
     return {
       name: tool.name,
       description: tool.description,
+      virtual: tool.virtual ?? false,
       arguments: args,
       example: this.generateExample(tool),
     };

--- a/tests/commands/tool/handler.test.ts
+++ b/tests/commands/tool/handler.test.ts
@@ -59,6 +59,7 @@ describe("ToolCommandHandler (integration)", () => {
     expect(result.data).toEqual({
       name: "create_project",
       description: "Creates a project",
+      virtual: false,
       arguments: { title: "string (required) - Project title" },
       example: `stitch-mcp tool create_project -d '{"title":"<title>"}'`,
     });

--- a/tests/commands/tool/steps/ListToolsStep.test.ts
+++ b/tests/commands/tool/steps/ListToolsStep.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, mock, beforeEach } from "bun:test";
 import { ListToolsStep } from "../../../../src/commands/tool/steps/ListToolsStep.js";
 import type { ToolContext } from "../../../../src/commands/tool/context.js";
 import { StitchToolClient } from '@google/stitch-sdk';
+import { createMockStitch, createMockProject } from '../../../../src/services/stitch-sdk/MockStitchSDK.js';
 
 describe("ListToolsStep (SDK)", () => {
   let step: ListToolsStep;
@@ -19,6 +20,7 @@ describe("ListToolsStep (SDK)", () => {
     return {
       input: { showSchema: false, output: "pretty", ...overrides },
       client: mockClient,
+      stitch: createMockStitch(createMockProject('test-proj', [])),
       virtualTools: [{ name: "virtual1", execute: mock() }] as any,
     };
   }
@@ -38,7 +40,7 @@ describe("ListToolsStep (SDK)", () => {
   });
 
   describe("run", () => {
-    it("calls listTools() on StitchToolClient (not getCapabilities())", async () => {
+    it("calls listTools() on StitchToolClient and tags tools with virtual field", async () => {
       const serverTools = [{ name: "server_tool", description: "desc" }];
       mockClient.listTools.mockResolvedValue({ tools: serverTools });
 
@@ -48,8 +50,13 @@ describe("ListToolsStep (SDK)", () => {
       expect(mockClient.listTools).toHaveBeenCalled();
       expect(context.result).toBeDefined();
       expect(context.result!.success).toBe(true);
-      expect(context.result!.data).toContainEqual(expect.objectContaining({ name: "virtual1" }));
-      expect(context.result!.data).toContainEqual(expect.objectContaining({ name: "server_tool" }));
+      // Virtual tools tagged with virtual: true
+      expect(context.result!.data).toContainEqual(expect.objectContaining({ name: "virtual1", virtual: true }));
+      // Server tools tagged with virtual: false
+      expect(context.result!.data).toContainEqual(expect.objectContaining({ name: "server_tool", virtual: false }));
+      // Execute function should be stripped from virtual tools
+      const virtualEntry = context.result!.data.find((t: any) => t.name === "virtual1");
+      expect(virtualEntry.execute).toBeUndefined();
     });
 
     it("should handle empty server tools", async () => {
@@ -60,6 +67,7 @@ describe("ListToolsStep (SDK)", () => {
 
       expect(context.result!.success).toBe(true);
       expect(context.result!.data).toHaveLength(1); // just the virtual tool
+      expect(context.result!.data[0].virtual).toBe(true);
     });
 
     it.skip('StitchToolClient auto-connects on first callTool() call', async () => {

--- a/tests/commands/tool/steps/ShowSchemaStep.test.ts
+++ b/tests/commands/tool/steps/ShowSchemaStep.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, mock, beforeEach } from "bun:test";
 import { ShowSchemaStep } from "../../../../src/commands/tool/steps/ShowSchemaStep.js";
 import type { ToolContext } from "../../../../src/commands/tool/context.js";
+import { createMockStitch, createMockProject } from '../../../../src/services/stitch-sdk/MockStitchSDK.js';
 
 describe("ShowSchemaStep", () => {
   let step: ShowSchemaStep;
@@ -17,6 +18,7 @@ describe("ShowSchemaStep", () => {
     return {
       input: { showSchema: false, output: "pretty", ...overrides },
       client: mockClient,
+      stitch: createMockStitch(createMockProject('test-proj', [])),
       virtualTools: [],
     };
   }
@@ -61,6 +63,7 @@ describe("ShowSchemaStep", () => {
       expect(context.result!.data).toEqual({
         name: "create_project",
         description: "Creates a project",
+        virtual: false,
         arguments: {
           title: "string (required) - Project title",
         },
@@ -82,6 +85,7 @@ describe("ShowSchemaStep", () => {
       const virtualTool = {
         name: "get_screen_code",
         description: "(Virtual) Gets code",
+        virtual: true,
         inputSchema: {
           type: "object",
           properties: { projectId: { type: "string" } },
@@ -97,6 +101,7 @@ describe("ShowSchemaStep", () => {
 
       expect(context.result!.success).toBe(true);
       expect(context.result!.data.name).toBe("get_screen_code");
+      expect(context.result!.data.virtual).toBe(true);
     });
   });
 });


### PR DESCRIPTION
Add a `virtual: boolean` field to every tool object returned by `list_tools`, enabling consumers to programmatically distinguish native MCP server tools from CLI-side virtual tools.

- Add `virtual?: boolean` to ToolInfo interface
- Tag virtual tools with `virtual: true` and strip execute fn
- Tag server tools with `virtual: false`
- Include virtual field in --schema output
- Update tests with proper MockStitch factories