### PR TITLE
🧹 refactor: simplify conditional header deletion in init ConfigStep

### DIFF
--- a/src/commands/init/steps/ConfigStep.ts
+++ b/src/commands/init/steps/ConfigStep.ts
@@ -130,8 +130,8 @@ export class ConfigStep implements CommandStep<InitContext> {
                 },
              };
              // Ensure optional deletion of other headers if they were there
-             if (config.mcpServers.stitch.headers['Authorization']) delete config.mcpServers.stitch.headers['Authorization'];
-             if (config.mcpServers.stitch.headers['X-Goog-User-Project']) delete config.mcpServers.stitch.headers['X-Goog-User-Project'];
+             delete config.mcpServers.stitch.headers['Authorization'];
+             delete config.mcpServers.stitch.headers['X-Goog-User-Project'];
 
              await fs.promises.writeFile(extensionPath, JSON.stringify(config, null, 4));
              spinner.succeed(`Stitch extension configured for HTTP with API Key`);


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed redundant `if` checks before `delete` operations in `src/commands/init/steps/ConfigStep.ts`.

💡 **Why:** How this improves maintainability
The `delete` operator in JavaScript/TypeScript is perfectly safe to call on non-existent properties (it simply returns `true` and does nothing). Therefore, checking if a property exists before deleting it adds unnecessary verbosity and complexity. Removing these checks makes the code cleaner and more idiomatic.

✅ **Verification:** How you confirmed the change is safe
1. Analyzed the surrounding code to ensure `config.mcpServers.stitch.headers` is always defined as an object before the deletion.
2. Ran the full test suite via `bun test` to confirm no regressions.
3. Verified via code review that the fix is correct and introduces zero side-effects.

✨ **Result:** The improvement achieved
Cleaner, more concise code that achieves the exact same functionality without redundant logic.

---
*PR created automatically by Jules for task [6851400527039167857](https://jules.google.com/task/6851400527039167857) started by @davideast*