### PR TITLE
🧹 Remove unused 'theme' import from spinner

### DIFF
--- a/src/ui/spinner.ts
+++ b/src/ui/spinner.ts
@@ -1,5 +1,5 @@
 import ora, { type Ora } from 'ora';
-import { theme, icons } from './theme.js';
+import { icons } from './theme.js';
 
 /**
  * Wrapper for ora spinner with consistent styling


### PR DESCRIPTION
🎯 **What:** Removed the unused `theme` import from `src/ui/spinner.ts`. The `icons` import was kept as it is actively used.
💡 **Why:** This improves the maintainability and cleanliness of the code by removing dead code, adhering to clean coding standards, and minimizing potential confusion for future developers maintaining this file.
✅ **Verification:** Verified by running `bun run build` and `bun test` to ensure that nothing is broken, and manually checked the `Spinner` implementation to ensure no dependencies on the `theme` import existed.
✨ **Result:** A cleaner import section without affecting any functionality in the application.

---
*PR created automatically by Jules for task [17993392299773790104](https://jules.google.com/task/17993392299773790104) started by @davideast*