### PR TITLE
fix: include API key env flag in Claude Code stdio instructions

### DIFF
--- a/src/services/mcp-config/handler.ts
+++ b/src/services/mcp-config/handler.ts
@@ -308,11 +308,18 @@ export class McpConfigHandler implements McpConfigService {
 
       case 'claude-code':
         if (transport === 'stdio') {
+          let envHint = '';
+          if (apiKey) {
+            envHint = `${theme.blue(`  -e STITCH_API_KEY=${apiKey} \\`)}\n`;
+          } else if (projectId) {
+            envHint = `${theme.blue(`  -e STITCH_PROJECT_ID=${projectId} \\`)}\n`;
+          }
           return (
             transportNote +
             `\n${theme.green('Setup Claude Code:')}\n\n` +
             `Run the following command to add the Stitch MCP server:\n\n` +
             `${theme.blue('claude mcp add stitch \\')}\n` +
+            envHint +
             `${theme.blue('  -- npx @_davideast/stitch-mcp proxy')}`
           );
         } else {

--- a/src/services/mcp-config/handler_apikey.test.ts
+++ b/src/services/mcp-config/handler_apikey.test.ts
@@ -63,6 +63,24 @@ describe('McpConfigHandler (API Key)', () => {
     }
   });
 
+  it('should generate Claude Code STDIO instructions with API key', async () => {
+    const input = {
+      client: 'claude-code' as const,
+      projectId: 'test-project',
+      accessToken: 'ignored',
+      transport: 'stdio' as const,
+      apiKey: 'test-api-key',
+    };
+
+    const result = await handler.generateConfig(input);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.instructions).toContain('-e STITCH_API_KEY=test-api-key');
+      expect(result.data.instructions).not.toContain('STITCH_PROJECT_ID');
+    }
+  });
+
   it('should generate Antigravity configuration with API key', async () => {
     const input = {
       client: 'antigravity' as const,


### PR DESCRIPTION
The `claude-code` + `stdio` path in `getInstructionsForClient()` was a hardcoded string that ignored the `apiKey` and `projectId` parameters. When a user selected Claude Code → API Key → MCP config → Proxy, the generated command was missing `-e STITCH_API_KEY=<key>`, so the proxy fell back to OAuth and failed.

  - Add `-e STITCH_API_KEY` / `STITCH_PROJECT_ID` env flags to the generated `claude mcp add` command
  - Matches the pattern already documented in [`connect-your-agent.md`](https://github.com/davideast/stitch-mcp/blob/main/docs/connect-your-agent.md#claude-code)
  - Add missing test for Claude Code + stdio + API key path