### PR TITLE
feat: add agent-friendly flags to site command

### DIFF
--- a/src/commands/site/command.ts
+++ b/src/commands/site/command.ts
@@ -10,7 +10,9 @@ export const command: CommandDefinition<any, SiteOptions> = {
   ],
   options: [
     { flags: '-o, --output <dir>', description: 'Output directory', defaultValue: '.' },
-    { flags: '-e, --export', description: 'Export screen-to-route config as build_site JSON', defaultValue: false }
+    { flags: '-e, --export', description: 'Export screen-to-route config as build_site JSON', defaultValue: false },
+    { flags: '-l, --list-screens', description: 'List all screens with suggested routes as JSON', defaultValue: false },
+    { flags: '-r, --routes <json>', description: 'JSON array of {screenId,route} mappings — generates site without TUI' },
   ],
   action: async (_args, options) => {
     try {
@@ -18,9 +20,11 @@ export const command: CommandDefinition<any, SiteOptions> = {
       const { SiteCommandHandler } = await import('./index.js');
       const handler = new SiteCommandHandler();
       await handler.execute({
-          projectId: parsedOptions.project,
-          outputDir: parsedOptions.output,
-          export: parsedOptions.export
+        projectId: parsedOptions.project,
+        outputDir: parsedOptions.output,
+        export: parsedOptions.export,
+        listScreens: parsedOptions.listScreens,
+        routes: parsedOptions.routes,
       });
       process.exit(0);
     } catch (error) {

--- a/src/commands/site/generate/handler.test.ts
+++ b/src/commands/site/generate/handler.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, mock, beforeEach } from 'bun:test';
+import { createMockStitch, createMockProject, createMockScreen } from '../../../services/stitch-sdk/MockStitchSDK.js';
+import { GenerateHandler } from './handler.js';
+import type { GenerateInput } from './spec.js';
+
+const PROJECT_ID = 'proj_abc';
+
+const mockGenerateSite = mock(() => Promise.resolve());
+
+mock.module('../../../lib/services/site/SiteService.js', () => ({
+  SiteService: { generateSite: mockGenerateSite },
+}));
+
+mock.module('../utils/fetchWithRetry.js', () => ({
+  fetchWithRetry: mock((url: string) => Promise.resolve(`<html>content for ${url}</html>`)),
+}));
+
+function makeClient(screens: any[]) {
+  return createMockStitch(createMockProject(PROJECT_ID, screens));
+}
+
+function makeInput(overrides: Partial<GenerateInput> = {}): GenerateInput {
+  return {
+    projectId: PROJECT_ID,
+    routesJson: [
+      { screenId: 'scr_1', route: '/' },
+      { screenId: 'scr_2', route: '/about' },
+    ],
+    outputDir: './output',
+    ...overrides,
+  };
+}
+
+describe('GenerateHandler', () => {
+  beforeEach(() => {
+    mockGenerateSite.mockClear();
+  });
+
+  it('returns success with pages when all screens resolve', async () => {
+    const client = makeClient([
+      createMockScreen({ screenId: 'scr_1', title: 'Home', getHtml: mock(() => Promise.resolve('https://cdn.example.com/home.html')) }),
+      createMockScreen({ screenId: 'scr_2', title: 'About', getHtml: mock(() => Promise.resolve('https://cdn.example.com/about.html')) }),
+    ]);
+
+    const handler = new GenerateHandler(client);
+    const result = await handler.execute(makeInput());
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.outputDir).toBe('./output');
+    expect(result.pages).toEqual([
+      { screenId: 'scr_1', route: '/' },
+      { screenId: 'scr_2', route: '/about' },
+    ]);
+    expect(mockGenerateSite).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns SCREEN_NOT_FOUND when a screenId does not exist in the project', async () => {
+    const client = makeClient([
+      createMockScreen({ screenId: 'scr_1', title: 'Home', getHtml: mock(() => Promise.resolve('https://cdn.example.com/home.html')) }),
+      // scr_2 is missing
+    ]);
+
+    const handler = new GenerateHandler(client);
+    const result = await handler.execute(makeInput());
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.code).toBe('SCREEN_NOT_FOUND');
+    expect(result.error.message).toContain('scr_2');
+  });
+
+  it('returns HTML_FETCH_FAILED when getHtml rejects', async () => {
+    const client = makeClient([
+      createMockScreen({ screenId: 'scr_1', title: 'Home', getHtml: mock(() => Promise.reject(new Error('cdn error'))) }),
+      createMockScreen({ screenId: 'scr_2', title: 'About', getHtml: mock(() => Promise.resolve('https://cdn.example.com/about.html')) }),
+    ]);
+
+    const handler = new GenerateHandler(client);
+    const result = await handler.execute(makeInput());
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.code).toBe('HTML_FETCH_FAILED');
+  });
+});

--- a/src/commands/site/generate/handler.ts
+++ b/src/commands/site/generate/handler.ts
@@ -1,0 +1,87 @@
+import type { Stitch } from '@google/stitch-sdk';
+import pLimit from 'p-limit';
+import type { GenerateSpec, GenerateInput, GenerateResult } from './spec.js';
+import { SiteService } from '../../../lib/services/site/SiteService.js';
+import { AssetGateway } from '../../../lib/server/AssetGateway.js';
+import { fetchWithRetry } from '../utils/fetchWithRetry.js';
+
+export class GenerateHandler implements GenerateSpec {
+  constructor(private readonly client: Stitch) {}
+
+  async execute(input: GenerateInput): Promise<GenerateResult> {
+    try {
+      const project = this.client.project(input.projectId);
+      const sdkScreens = await project.screens();
+      const screenMap = new Map(sdkScreens.map((s: any) => [s.screenId, s]));
+
+      // Validate all requested screenIds exist
+      const missingIds = input.routesJson
+        .map(r => r.screenId)
+        .filter(id => !screenMap.has(id));
+
+      if (missingIds.length > 0) {
+        return {
+          success: false,
+          error: {
+            code: 'SCREEN_NOT_FOUND',
+            message: `Screen IDs not found in project: ${missingIds.join(', ')}`,
+            hint: `Run stitch site -p ${input.projectId} --list-screens to see available screen IDs.`,
+            recoverable: true,
+          },
+        };
+      }
+
+      // Fetch HTML for each screen
+      const limit = pLimit(3);
+      const htmlContent = new Map<string, string>();
+      const errors: string[] = [];
+
+      await Promise.all(
+        input.routesJson.map(r => limit(async () => {
+          const screen = screenMap.get(r.screenId)!;
+          try {
+            const htmlUrl = await screen.getHtml();
+            const html = htmlUrl ? await fetchWithRetry(htmlUrl) : '';
+            htmlContent.set(r.screenId, html);
+          } catch (e: any) {
+            errors.push(`${r.screenId}: ${e.message}`);
+          }
+        }))
+      );
+
+      if (errors.length > 0) {
+        return {
+          success: false,
+          error: {
+            code: 'HTML_FETCH_FAILED',
+            message: `Failed to fetch HTML for screens: ${errors.join('; ')}`,
+            recoverable: false,
+          },
+        };
+      }
+
+      const config = {
+        projectId: input.projectId,
+        routes: input.routesJson.map(r => ({ screenId: r.screenId, route: r.route, status: 'included' as const })),
+      };
+
+      const assetGateway = new AssetGateway();
+      await SiteService.generateSite(config, htmlContent, assetGateway, input.outputDir);
+
+      return {
+        success: true,
+        outputDir: input.outputDir,
+        pages: input.routesJson.map(r => ({ screenId: r.screenId, route: r.route })),
+      };
+    } catch (e: any) {
+      return {
+        success: false,
+        error: {
+          code: 'GENERATE_FAILED',
+          message: e.message,
+          recoverable: false,
+        },
+      };
+    }
+  }
+}

--- a/src/commands/site/generate/spec.test.ts
+++ b/src/commands/site/generate/spec.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'bun:test';
+import { GenerateInputSchema } from './spec.js';
+
+describe('GenerateInputSchema', () => {
+  const validRoutes = JSON.stringify([
+    { screenId: 'scr_1', route: '/' },
+    { screenId: 'scr_2', route: '/about' },
+  ]);
+
+  it('accepts valid input', () => {
+    const result = GenerateInputSchema.safeParse({ projectId: 'proj_abc', routesJson: validRoutes });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.routesJson).toEqual([
+      { screenId: 'scr_1', route: '/' },
+      { screenId: 'scr_2', route: '/about' },
+    ]);
+  });
+
+  it('rejects malformed JSON in routesJson', () => {
+    const result = GenerateInputSchema.safeParse({ projectId: 'proj_abc', routesJson: 'not json' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a route that does not start with /', () => {
+    const bad = JSON.stringify([{ screenId: 'scr_1', route: 'about' }]);
+    const result = GenerateInputSchema.safeParse({ projectId: 'proj_abc', routesJson: bad });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an empty screenId', () => {
+    const bad = JSON.stringify([{ screenId: '', route: '/' }]);
+    const result = GenerateInputSchema.safeParse({ projectId: 'proj_abc', routesJson: bad });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an empty projectId', () => {
+    const result = GenerateInputSchema.safeParse({ projectId: '', routesJson: validRoutes });
+    expect(result.success).toBe(false);
+  });
+
+  it('defaults outputDir to "."', () => {
+    const result = GenerateInputSchema.safeParse({ projectId: 'proj_abc', routesJson: validRoutes });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.outputDir).toBe('.');
+  });
+});

--- a/src/commands/site/generate/spec.ts
+++ b/src/commands/site/generate/spec.ts
@@ -1,0 +1,63 @@
+import { z } from 'zod';
+
+// 1. VALIDATION HELPERS
+const RouteEntrySchema = z.object({
+  screenId: z.string().min(1, 'screenId is required'),
+  route: z.string().startsWith('/', 'route must start with /'),
+});
+
+const RoutesJsonSchema = z.string().transform((str, ctx) => {
+  try {
+    const parsed = JSON.parse(str);
+    const result = z.array(RouteEntrySchema).safeParse(parsed);
+    if (!result.success) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: result.error.issues[0]?.message ?? 'Invalid routes array' });
+      return z.NEVER;
+    }
+    return result.data;
+  } catch {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'routes must be valid JSON' });
+    return z.NEVER;
+  }
+});
+
+// 2. INPUT
+export const GenerateInputSchema = z.object({
+  projectId: z.string().min(1, 'projectId is required'),
+  routesJson: RoutesJsonSchema,
+  outputDir: z.string().default('.'),
+});
+export type GenerateInput = z.infer<typeof GenerateInputSchema>;
+
+// 3. ERROR CODES
+export const GenerateErrorCode = z.enum([
+  'INVALID_ROUTES',
+  'SCREEN_NOT_FOUND',
+  'HTML_FETCH_FAILED',
+  'GENERATE_FAILED',
+]);
+export type GenerateErrorCode = z.infer<typeof GenerateErrorCode>;
+
+// 4. RESULT
+export type GenerateSuccess = {
+  success: true;
+  outputDir: string;
+  pages: Array<{ screenId: string; route: string }>;
+};
+
+export type GenerateFailure = {
+  success: false;
+  error: {
+    code: GenerateErrorCode;
+    message: string;
+    hint?: string;
+    recoverable: boolean;
+  };
+};
+
+export type GenerateResult = GenerateSuccess | GenerateFailure;
+
+// 5. INTERFACE
+export interface GenerateSpec {
+  execute(input: GenerateInput): Promise<GenerateResult>;
+}

--- a/src/commands/site/index.tsx
+++ b/src/commands/site/index.tsx
@@ -6,18 +6,50 @@ import { SiteBuilder } from './ui/SiteBuilder.js';
 import { SiteService } from '../../lib/services/site/SiteService.js';
 import { AssetGateway } from '../../lib/server/AssetGateway.js';
 import { SiteManifest } from './utils/SiteManifest.js';
+import { ListScreensHandler } from './list-screens/handler.js';
+import { ListScreensInputSchema } from './list-screens/spec.js';
+import { GenerateHandler } from './generate/handler.js';
+import { GenerateInputSchema } from './generate/spec.js';
 import type { SiteConfig, UIScreen } from '../../lib/services/site/types.js';
 
 interface SiteCommandOptions {
   projectId: string;
   outputDir?: string;
   export?: boolean;
+  listScreens?: boolean;
+  routes?: string;
 }
 
 export class SiteCommandHandler {
   constructor(private client: Stitch = stitch) {}
 
   async execute(options: SiteCommandOptions) {
+    if (options.listScreens) {
+      const input = ListScreensInputSchema.safeParse({ projectId: options.projectId });
+      if (!input.success) {
+        console.log(JSON.stringify({ success: false, error: { code: 'INVALID_INPUT', message: input.error.issues[0]?.message } }, null, 2));
+        return;
+      }
+      const result = await new ListScreensHandler(this.client).execute(input.data);
+      console.log(JSON.stringify(result, null, 2));
+      return;
+    }
+
+    if (options.routes !== undefined) {
+      const input = GenerateInputSchema.safeParse({
+        projectId: options.projectId,
+        routesJson: options.routes,
+        outputDir: options.outputDir,
+      });
+      if (!input.success) {
+        console.log(JSON.stringify({ success: false, error: { code: 'INVALID_INPUT', message: input.error.issues[0]?.message } }, null, 2));
+        return;
+      }
+      const result = await new GenerateHandler(this.client).execute(input.data);
+      console.log(JSON.stringify(result, null, 2));
+      return;
+    }
+
     if (options.export) {
       const project = this.client.project(options.projectId);
       const sdkScreens = await project.screens();

--- a/src/commands/site/list-screens/handler.test.ts
+++ b/src/commands/site/list-screens/handler.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, mock } from 'bun:test';
+import { createMockStitch, createMockProject, createMockScreen } from '../../../services/stitch-sdk/MockStitchSDK.js';
+import { ListScreensHandler } from './handler.js';
+
+const PROJECT_ID = 'proj_abc';
+
+function makeClient(screens: any[]) {
+  return createMockStitch(createMockProject(PROJECT_ID, screens));
+}
+
+describe('ListScreensHandler', () => {
+  it('returns screens with suggestedRoutes on success', async () => {
+    const client = makeClient([
+      createMockScreen({ screenId: 'scr_1', title: 'Home', getHtml: mock(() => Promise.resolve('https://cdn.example.com/home.html')) }),
+      createMockScreen({ screenId: 'scr_2', title: 'About Us', getHtml: mock(() => Promise.resolve('https://cdn.example.com/about.html')) }),
+    ]);
+
+    const handler = new ListScreensHandler(client);
+    const result = await handler.execute({ projectId: PROJECT_ID });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.projectId).toBe(PROJECT_ID);
+    expect(result.screens).toHaveLength(2);
+    expect(result.screens).toContainEqual({ screenId: 'scr_1', title: 'Home', suggestedRoute: '/', hasHtml: true });
+    expect(result.screens).toContainEqual({ screenId: 'scr_2', title: 'About Us', suggestedRoute: '/about-us', hasHtml: true });
+  });
+
+  it('marks hasHtml false when getHtml rejects', async () => {
+    const client = makeClient([
+      createMockScreen({ screenId: 'scr_1', title: 'Home', getHtml: mock(() => Promise.reject(new Error('no code'))) }),
+    ]);
+
+    const handler = new ListScreensHandler(client);
+    const result = await handler.execute({ projectId: PROJECT_ID });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.screens).toContainEqual(expect.objectContaining({ screenId: 'scr_1', hasHtml: false }));
+  });
+
+  it('returns SCREENS_FETCH_FAILED when project.screens() throws', async () => {
+    const client = makeClient([]);
+    (client.project as any).mockImplementation(() => ({
+      screens: mock(() => Promise.reject(new Error('network error'))),
+    }));
+
+    const handler = new ListScreensHandler(client);
+    const result = await handler.execute({ projectId: PROJECT_ID });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.code).toBe('SCREENS_FETCH_FAILED');
+  });
+});

--- a/src/commands/site/list-screens/handler.ts
+++ b/src/commands/site/list-screens/handler.ts
@@ -1,0 +1,39 @@
+import type { Stitch } from '@google/stitch-sdk';
+import pLimit from 'p-limit';
+import type { ListScreensSpec, ListScreensInput, ListScreensResult } from './spec.js';
+import { suggestRoute } from '../utils/suggestRoute.js';
+
+export class ListScreensHandler implements ListScreensSpec {
+  constructor(private readonly client: Stitch) {}
+
+  async execute(input: ListScreensInput): Promise<ListScreensResult> {
+    try {
+      const project = this.client.project(input.projectId);
+      const sdkScreens = await project.screens();
+
+      const limit = pLimit(3);
+      const screens = await Promise.all(
+        sdkScreens.map((s: any) => limit(async () => {
+          const htmlUrl = await s.getHtml().catch(() => null);
+          return {
+            screenId: s.screenId,
+            title: s.title ?? s.screenId,
+            suggestedRoute: suggestRoute(s.title ?? s.screenId),
+            hasHtml: htmlUrl !== null,
+          };
+        }))
+      );
+
+      return { success: true, projectId: input.projectId, screens };
+    } catch (e: any) {
+      return {
+        success: false,
+        error: {
+          code: 'SCREENS_FETCH_FAILED',
+          message: e.message,
+          recoverable: false,
+        },
+      };
+    }
+  }
+}

--- a/src/commands/site/list-screens/spec.test.ts
+++ b/src/commands/site/list-screens/spec.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'bun:test';
+import { ListScreensInputSchema } from './spec.js';
+
+describe('ListScreensInputSchema', () => {
+  it('accepts a valid projectId', () => {
+    const result = ListScreensInputSchema.safeParse({ projectId: 'proj_abc' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an empty projectId', () => {
+    const result = ListScreensInputSchema.safeParse({ projectId: '' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a missing projectId', () => {
+    const result = ListScreensInputSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/commands/site/list-screens/spec.ts
+++ b/src/commands/site/list-screens/spec.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+
+// 1. INPUT
+export const ListScreensInputSchema = z.object({
+  projectId: z.string().min(1, 'projectId is required'),
+});
+export type ListScreensInput = z.infer<typeof ListScreensInputSchema>;
+
+// 2. ERROR CODES
+export const ListScreensErrorCode = z.enum([
+  'PROJECT_NOT_FOUND',
+  'SCREENS_FETCH_FAILED',
+]);
+export type ListScreensErrorCode = z.infer<typeof ListScreensErrorCode>;
+
+// 3. RESULT
+export type ListScreensSuccess = {
+  success: true;
+  projectId: string;
+  screens: Array<{
+    screenId: string;
+    title: string;
+    suggestedRoute: string;
+    hasHtml: boolean;
+  }>;
+};
+
+export type ListScreensFailure = {
+  success: false;
+  error: {
+    code: ListScreensErrorCode;
+    message: string;
+    recoverable: boolean;
+  };
+};
+
+export type ListScreensResult = ListScreensSuccess | ListScreensFailure;
+
+// 4. INTERFACE
+export interface ListScreensSpec {
+  execute(input: ListScreensInput): Promise<ListScreensResult>;
+}

--- a/src/commands/site/spec.ts
+++ b/src/commands/site/spec.ts
@@ -4,6 +4,8 @@ export const SiteOptionsSchema = z.object({
   project: z.string(),
   output: z.string().default('.'),
   export: z.boolean().default(false),
+  listScreens: z.boolean().default(false),
+  routes: z.string().optional(),
 });
 
 export type SiteOptions = z.infer<typeof SiteOptionsSchema>;

--- a/src/commands/site/utils/suggestRoute.test.ts
+++ b/src/commands/site/utils/suggestRoute.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'bun:test';
+import { suggestRoute } from './suggestRoute.js';
+
+describe('suggestRoute', () => {
+  it('maps "Home" to /', () => {
+    expect(suggestRoute('Home')).toBe('/');
+  });
+
+  it('maps "About Us" to /about-us', () => {
+    expect(suggestRoute('About Us')).toBe('/about-us');
+  });
+
+  it('maps "Landing" to /', () => {
+    expect(suggestRoute('Landing')).toBe('/');
+  });
+
+  it('maps "Landing Page" to /', () => {
+    expect(suggestRoute('Landing Page')).toBe('/');
+  });
+
+  it('maps "Index" to /', () => {
+    expect(suggestRoute('Index')).toBe('/');
+  });
+
+  it('strips special characters and collapses hyphens', () => {
+    expect(suggestRoute('Terms & Conditions!')).toBe('/terms-conditions');
+  });
+
+  it('collapses multiple spaces', () => {
+    expect(suggestRoute('Our  Team')).toBe('/our-team');
+  });
+
+  it('maps a single-word title', () => {
+    expect(suggestRoute('Pricing')).toBe('/pricing');
+  });
+});

--- a/src/commands/site/utils/suggestRoute.ts
+++ b/src/commands/site/utils/suggestRoute.ts
@@ -1,0 +1,11 @@
+const HOME_SLUGS = new Set(['home', 'landing', 'landing-page', 'index']);
+
+export function suggestRoute(title: string): string {
+  const slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-');
+  return HOME_SLUGS.has(slug) ? '/' : `/${slug}`;
+}


### PR DESCRIPTION
Add `-l/--list-screens` and `-r/--routes` flags to the site command so agents can discover screens and generate sites without the TUI.

- --list-screens (`-l`): outputs JSON of all screens with suggested routes
- --routes (`-r`): accepts a JSON routes array and generates the site directly, skipping the interactive builder entirely
- Each operation is a typed vertical slice (spec + handler) with exhaustive error codes and Result types. The handlers never throw.
- `suggestRoute` utility derives URL slugs from screen titles