### PR TITLE
feat: add agent-friendly flags to serve command

### DIFF
--- a/src/commands/serve/command.ts
+++ b/src/commands/serve/command.ts
@@ -1,6 +1,8 @@
 import { type CommandDefinition } from '../../framework/CommandDefinition.js';
 import { theme, icons } from '../../ui/theme.js';
 import { ServeOptionsSchema, type ServeOptions } from './spec.js';
+import { ListScreensInputSchema } from './list-screens/spec.js';
+import { JsonServerInputSchema } from './json-server/spec.js';
 
 export const command: CommandDefinition<any, ServeOptions> = {
   name: 'serve',
@@ -8,12 +10,44 @@ export const command: CommandDefinition<any, ServeOptions> = {
   requiredOptions: [
     { flags: '-p, --project <id>', description: 'Project ID' }
   ],
+  options: [
+    { flags: '-l, --list-screens', description: 'List all screens with their server paths as JSON', defaultValue: false },
+    { flags: '--json', description: 'Start server in non-interactive mode and output JSON when ready', defaultValue: false },
+  ],
   action: async (_args, options) => {
     try {
       const parsedOptions = ServeOptionsSchema.parse(options);
+      const { stitch } = await import('@google/stitch-sdk');
+
+      if (parsedOptions.listScreens) {
+        const input = ListScreensInputSchema.safeParse({ projectId: parsedOptions.project });
+        if (!input.success) {
+          console.log(JSON.stringify({ success: false, error: { code: 'INVALID_INPUT', message: input.error.issues[0]?.message } }, null, 2));
+          process.exit(1);
+        }
+        const { ListScreensHandler } = await import('./list-screens/handler.js');
+        const result = await new ListScreensHandler(stitch).execute(input.data);
+        console.log(JSON.stringify(result, null, 2));
+        process.exit(result.success ? 0 : 1);
+      }
+
+      if (parsedOptions.json) {
+        const input = JsonServerInputSchema.safeParse({ projectId: parsedOptions.project });
+        if (!input.success) {
+          console.log(JSON.stringify({ success: false, error: { code: 'INVALID_INPUT', message: input.error.issues[0]?.message } }, null, 2));
+          process.exit(1);
+        }
+        const { JsonServerHandler } = await import('./json-server/handler.js');
+        const result = await new JsonServerHandler(stitch).execute(input.data);
+        console.log(JSON.stringify(result, null, 2));
+        if (!result.success) process.exit(1);
+        // Keep process alive — server runs until killed
+        await new Promise(() => {});
+        return;
+      }
+
       const { ServeHandler } = await import('./handler.js');
       const { ServeView } = await import('./ServeView.js');
-      const { stitch } = await import('@google/stitch-sdk');
       const { render } = await import('ink');
       const React = await import('react');
 
@@ -21,7 +55,7 @@ export const command: CommandDefinition<any, ServeOptions> = {
       const result = await handler.execute(parsedOptions.project);
 
       if (!result.success) {
-        console.error(theme.red(`\n${icons.error} Failed: ${result.error}`));
+        console.error(theme.red(`\n${icons.error} Failed: ${result.error.message}`));
         process.exit(1);
       }
 
@@ -37,7 +71,6 @@ export const command: CommandDefinition<any, ServeOptions> = {
         screens: result.screens,
       }));
       await instance.waitUntilExit();
-
       process.exit(0);
     } catch (error) {
       console.error(theme.red(`\n${icons.error} Unexpected error:`), error);

--- a/src/commands/serve/handler.test.ts
+++ b/src/commands/serve/handler.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, mock } from 'bun:test';
+import { createMockStitch, createMockProject, createMockScreen } from '../../services/stitch-sdk/MockStitchSDK.js';
+import { ServeHandler } from './handler.js';
+
+const PROJECT_ID = 'proj_abc';
+
+function makeClient(screens: any[]) {
+  return createMockStitch(createMockProject(PROJECT_ID, screens));
+}
+
+describe('ServeHandler', () => {
+  it('returns screens with codeUrls on success', async () => {
+    const client = makeClient([
+      createMockScreen({ screenId: 'scr_1', title: 'Home', getHtml: mock(() => Promise.resolve('https://cdn.example.com/home.html')) }),
+      createMockScreen({ screenId: 'scr_2', title: 'About', getHtml: mock(() => Promise.resolve('https://cdn.example.com/about.html')) }),
+    ]);
+
+    const handler = new ServeHandler(client);
+    const result = await handler.execute(PROJECT_ID);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.projectId).toBe(PROJECT_ID);
+    expect(result.screens).toHaveLength(2);
+    expect(result.screens).toContainEqual(expect.objectContaining({ screenId: 'scr_1', title: 'Home' }));
+  });
+
+  it('excludes screens where getHtml rejects', async () => {
+    const client = makeClient([
+      createMockScreen({ screenId: 'scr_1', title: 'Home', getHtml: mock(() => Promise.resolve('https://cdn.example.com/home.html')) }),
+      createMockScreen({ screenId: 'scr_2', title: 'No HTML', getHtml: mock(() => Promise.reject(new Error('no code'))) }),
+    ]);
+
+    const handler = new ServeHandler(client);
+    const result = await handler.execute(PROJECT_ID);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.screens).toHaveLength(1);
+    expect(result.screens[0]?.screenId).toBe('scr_1');
+  });
+
+  it('returns SCREENS_FETCH_FAILED when project.screens() throws', async () => {
+    const client = makeClient([]);
+    (client.project as any).mockImplementation(() => ({
+      screens: mock(() => Promise.reject(new Error('network error'))),
+      data: null,
+    }));
+
+    const handler = new ServeHandler(client);
+    const result = await handler.execute(PROJECT_ID);
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.code).toBe('SCREENS_FETCH_FAILED');
+  });
+});

--- a/src/commands/serve/handler.ts
+++ b/src/commands/serve/handler.ts
@@ -1,44 +1,26 @@
 import type { Stitch } from '@google/stitch-sdk';
 import pLimit from 'p-limit';
+import type { ServeSpec, ServeResult } from './spec.js';
 
-interface CodeScreen {
-  screenId: string;
-  title: string;
-  codeUrl: string;
-}
-
-type ServeHandlerResult = {
-  success: true;
-  projectId: string;
-  projectTitle: string;
-  screens: CodeScreen[];
-} | {
-  success: false;
-  error: string;
-};
-
-export class ServeHandler {
+export class ServeHandler implements ServeSpec {
   constructor(private readonly stitch: Stitch) {}
 
-  async execute(projectId: string): Promise<ServeHandlerResult> {
+  async execute(projectId: string): Promise<ServeResult> {
     try {
       const project = this.stitch.project(projectId);
       const screens = await project.screens();
 
-      // Throttle concurrent API calls
       const limit = pLimit(3);
       const withHtml = await Promise.all(
-        screens.map((s: any) => limit(async () => ({
-          screenId: s.screenId,
-          title: s.title ?? s.screenId,
-          codeUrl: await s.getHtml(),
-        })))
+        screens.map((s: any) => limit(async () => {
+          const codeUrl = await s.getHtml().catch(() => null);
+          return { screenId: s.screenId, title: s.title ?? s.screenId, codeUrl };
+        }))
       );
 
-      const filtered = withHtml.filter(s => s.codeUrl !== null);
-
-      // Sort alphabetically by title
-      filtered.sort((a, b) => a.title.localeCompare(b.title));
+      const filtered = withHtml
+        .filter(s => s.codeUrl !== null)
+        .sort((a, b) => a.title.localeCompare(b.title));
 
       return {
         success: true,
@@ -47,7 +29,10 @@ export class ServeHandler {
         screens: filtered,
       };
     } catch (e: any) {
-      return { success: false, error: e.message };
+      return {
+        success: false,
+        error: { code: 'SCREENS_FETCH_FAILED', message: e.message, recoverable: false },
+      };
     }
   }
 }

--- a/src/commands/serve/json-server/handler.test.ts
+++ b/src/commands/serve/json-server/handler.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, mock, beforeEach } from 'bun:test';
+import { createMockStitch, createMockProject, createMockScreen } from '../../../services/stitch-sdk/MockStitchSDK.js';
+
+const mockStart = mock(() => Promise.resolve('http://localhost:5173'));
+const mockMount = mock(() => {});
+const mockStop = mock(() => {});
+
+mock.module('../../../lib/server/vite/StitchViteServer.js', () => ({
+  StitchViteServer: class {
+    start = mockStart;
+    mount = mockMount;
+    stop = mockStop;
+  },
+}));
+
+mock.module('../../../ui/copy-behaviors/clipboard.js', () => ({
+  downloadText: mock((url: string) => Promise.resolve(`<html>content for ${url}</html>`)),
+}));
+
+const { JsonServerHandler } = await import('./handler.js');
+
+const PROJECT_ID = 'proj_abc';
+
+function makeClient(screens: any[]) {
+  return createMockStitch(createMockProject(PROJECT_ID, screens));
+}
+
+describe('JsonServerHandler', () => {
+  beforeEach(() => {
+    mockStart.mockClear();
+    mockMount.mockClear();
+    mockStop.mockClear();
+  });
+
+  it('returns ready result with url and screen urls', async () => {
+    const client = makeClient([
+      createMockScreen({ screenId: 'scr_1', title: 'Home', getHtml: mock(() => Promise.resolve('https://cdn.example.com/home.html')) }),
+    ]);
+
+    const handler = new JsonServerHandler(client);
+    const result = await handler.execute({ projectId: PROJECT_ID });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.url).toBe('http://localhost:5173');
+    expect(result.screens).toContainEqual({
+      screenId: 'scr_1',
+      title: 'Home',
+      url: 'http://localhost:5173/screens/scr_1',
+    });
+  });
+
+  it('returns SERVER_START_FAILED when server fails to start', async () => {
+    mockStart.mockImplementationOnce(() => Promise.reject(new Error('port in use')));
+
+    const client = makeClient([
+      createMockScreen({ screenId: 'scr_1', title: 'Home', getHtml: mock(() => Promise.resolve('https://cdn.example.com/home.html')) }),
+    ]);
+
+    const handler = new JsonServerHandler(client);
+    const result = await handler.execute({ projectId: PROJECT_ID });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.code).toBe('SERVER_START_FAILED');
+  });
+
+  it('returns SCREENS_FETCH_FAILED when project.screens() throws', async () => {
+    const client = makeClient([]);
+    (client.project as any).mockImplementation(() => ({
+      screens: mock(() => Promise.reject(new Error('network error'))),
+      data: null,
+    }));
+
+    const handler = new JsonServerHandler(client);
+    const result = await handler.execute({ projectId: PROJECT_ID });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.code).toBe('SCREENS_FETCH_FAILED');
+  });
+});

--- a/src/commands/serve/json-server/handler.ts
+++ b/src/commands/serve/json-server/handler.ts
@@ -1,0 +1,62 @@
+import type { Stitch } from '@google/stitch-sdk';
+import pLimit from 'p-limit';
+import { StitchViteServer } from '../../../lib/server/vite/StitchViteServer.js';
+import { downloadText } from '../../../ui/copy-behaviors/clipboard.js';
+import type { JsonServerSpec, JsonServerInput, JsonServerResult } from './spec.js';
+
+export class JsonServerHandler implements JsonServerSpec {
+  constructor(private readonly client: Stitch) {}
+
+  async execute(input: JsonServerInput): Promise<JsonServerResult> {
+    let sdkScreens: any[];
+
+    try {
+      const project = this.client.project(input.projectId);
+      sdkScreens = await project.screens();
+    } catch (e: any) {
+      return {
+        success: false,
+        error: { code: 'SCREENS_FETCH_FAILED', message: e.message, recoverable: false },
+      };
+    }
+
+    const server = new StitchViteServer();
+    let baseUrl: string;
+
+    try {
+      baseUrl = await server.start(0);
+    } catch (e: any) {
+      return {
+        success: false,
+        error: { code: 'SERVER_START_FAILED', message: e.message, recoverable: false },
+      };
+    }
+
+    // Mount screens concurrently
+    const limit = pLimit(3);
+    const screens: Array<{ screenId: string; title: string; url: string }> = [];
+
+    await Promise.all(
+      sdkScreens.map((s: any) => limit(async () => {
+        try {
+          const codeUrl = await s.getHtml();
+          if (codeUrl) {
+            const html = await downloadText(codeUrl);
+            server.mount(`/screens/${s.screenId}`, html);
+          }
+          screens.push({
+            screenId: s.screenId,
+            title: s.title ?? s.screenId,
+            url: `${baseUrl}/screens/${s.screenId}`,
+          });
+        } catch {
+          // Skip screens that fail to load
+        }
+      }))
+    );
+
+    screens.sort((a, b) => a.title.localeCompare(b.title));
+
+    return { success: true, url: baseUrl, screens };
+  }
+}

--- a/src/commands/serve/json-server/spec.ts
+++ b/src/commands/serve/json-server/spec.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+
+// 1. INPUT
+export const JsonServerInputSchema = z.object({
+  projectId: z.string().min(1, 'projectId is required'),
+});
+export type JsonServerInput = z.infer<typeof JsonServerInputSchema>;
+
+// 2. ERROR CODES
+export const JsonServerErrorCode = z.enum([
+  'SCREENS_FETCH_FAILED',
+  'SERVER_START_FAILED',
+]);
+export type JsonServerErrorCode = z.infer<typeof JsonServerErrorCode>;
+
+// 3. RESULT — emitted once to stdout when server is ready
+export type JsonServerReady = {
+  success: true;
+  url: string;
+  screens: Array<{ screenId: string; title: string; url: string }>;
+};
+
+export type JsonServerFailure = {
+  success: false;
+  error: {
+    code: JsonServerErrorCode;
+    message: string;
+    recoverable: boolean;
+  };
+};
+
+export type JsonServerResult = JsonServerReady | JsonServerFailure;
+
+// 4. INTERFACE
+export interface JsonServerSpec {
+  execute(input: JsonServerInput): Promise<JsonServerResult>;
+}

--- a/src/commands/serve/list-screens/handler.test.ts
+++ b/src/commands/serve/list-screens/handler.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, mock } from 'bun:test';
+import { createMockStitch, createMockProject, createMockScreen } from '../../../services/stitch-sdk/MockStitchSDK.js';
+import { ListScreensHandler } from './handler.js';
+
+const PROJECT_ID = 'proj_abc';
+
+function makeClient(screens: any[]) {
+  return createMockStitch(createMockProject(PROJECT_ID, screens));
+}
+
+describe('ListScreensHandler (serve)', () => {
+  it('returns screens with deterministic /screens/<screenId> paths', async () => {
+    const client = makeClient([
+      createMockScreen({ screenId: 'scr_1', title: 'Home', getHtml: mock(() => Promise.resolve('https://cdn.example.com/home.html')) }),
+      createMockScreen({ screenId: 'scr_2', title: 'About', getHtml: mock(() => Promise.resolve('https://cdn.example.com/about.html')) }),
+    ]);
+
+    const handler = new ListScreensHandler(client);
+    const result = await handler.execute({ projectId: PROJECT_ID });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.projectId).toBe(PROJECT_ID);
+    expect(result.screens).toContainEqual({ screenId: 'scr_1', title: 'Home', path: '/screens/scr_1', hasHtml: true });
+    expect(result.screens).toContainEqual({ screenId: 'scr_2', title: 'About', path: '/screens/scr_2', hasHtml: true });
+  });
+
+  it('marks hasHtml false when getHtml rejects', async () => {
+    const client = makeClient([
+      createMockScreen({ screenId: 'scr_1', title: 'Home', getHtml: mock(() => Promise.reject(new Error('no code'))) }),
+    ]);
+
+    const handler = new ListScreensHandler(client);
+    const result = await handler.execute({ projectId: PROJECT_ID });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.screens).toContainEqual(expect.objectContaining({ screenId: 'scr_1', hasHtml: false }));
+  });
+
+  it('returns SCREENS_FETCH_FAILED when project.screens() throws', async () => {
+    const client = makeClient([]);
+    (client.project as any).mockImplementation(() => ({
+      screens: mock(() => Promise.reject(new Error('network error'))),
+    }));
+
+    const handler = new ListScreensHandler(client);
+    const result = await handler.execute({ projectId: PROJECT_ID });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.code).toBe('SCREENS_FETCH_FAILED');
+  });
+});

--- a/src/commands/serve/list-screens/handler.ts
+++ b/src/commands/serve/list-screens/handler.ts
@@ -1,0 +1,34 @@
+import type { Stitch } from '@google/stitch-sdk';
+import pLimit from 'p-limit';
+import type { ListScreensSpec, ListScreensInput, ListScreensResult } from './spec.js';
+
+export class ListScreensHandler implements ListScreensSpec {
+  constructor(private readonly client: Stitch) {}
+
+  async execute(input: ListScreensInput): Promise<ListScreensResult> {
+    try {
+      const project = this.client.project(input.projectId);
+      const sdkScreens = await project.screens();
+
+      const limit = pLimit(3);
+      const screens = await Promise.all(
+        sdkScreens.map((s: any) => limit(async () => {
+          const htmlUrl = await s.getHtml().catch(() => null);
+          return {
+            screenId: s.screenId,
+            title: s.title ?? s.screenId,
+            path: `/screens/${s.screenId}`,
+            hasHtml: htmlUrl !== null,
+          };
+        }))
+      );
+
+      return { success: true, projectId: input.projectId, screens };
+    } catch (e: any) {
+      return {
+        success: false,
+        error: { code: 'SCREENS_FETCH_FAILED', message: e.message, recoverable: false },
+      };
+    }
+  }
+}

--- a/src/commands/serve/list-screens/spec.ts
+++ b/src/commands/serve/list-screens/spec.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod';
+
+// 1. INPUT
+export const ListScreensInputSchema = z.object({
+  projectId: z.string().min(1, 'projectId is required'),
+});
+export type ListScreensInput = z.infer<typeof ListScreensInputSchema>;
+
+// 2. ERROR CODES
+export const ListScreensErrorCode = z.enum([
+  'SCREENS_FETCH_FAILED',
+]);
+export type ListScreensErrorCode = z.infer<typeof ListScreensErrorCode>;
+
+// 3. RESULT
+export type ListScreensSuccess = {
+  success: true;
+  projectId: string;
+  screens: Array<{
+    screenId: string;
+    title: string;
+    path: string;
+    hasHtml: boolean;
+  }>;
+};
+
+export type ListScreensFailure = {
+  success: false;
+  error: {
+    code: ListScreensErrorCode;
+    message: string;
+    recoverable: boolean;
+  };
+};
+
+export type ListScreensResult = ListScreensSuccess | ListScreensFailure;
+
+// 4. INTERFACE
+export interface ListScreensSpec {
+  execute(input: ListScreensInput): Promise<ListScreensResult>;
+}

--- a/src/commands/serve/spec.test.ts
+++ b/src/commands/serve/spec.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'bun:test';
+import { ServeOptionsSchema } from './spec.js';
+
+describe('ServeOptionsSchema', () => {
+  it('accepts a valid project id', () => {
+    const result = ServeOptionsSchema.safeParse({ project: 'proj_abc' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a missing project', () => {
+    const result = ServeOptionsSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  it('defaults listScreens to false', () => {
+    const result = ServeOptionsSchema.safeParse({ project: 'proj_abc' });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.listScreens).toBe(false);
+  });
+
+  it('defaults json to false', () => {
+    const result = ServeOptionsSchema.safeParse({ project: 'proj_abc' });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.json).toBe(false);
+  });
+});

--- a/src/commands/serve/spec.ts
+++ b/src/commands/serve/spec.ts
@@ -1,7 +1,39 @@
 import { z } from 'zod';
 
+// 1. INPUT
 export const ServeOptionsSchema = z.object({
   project: z.string(),
+  listScreens: z.boolean().default(false),
+  json: z.boolean().default(false),
 });
-
 export type ServeOptions = z.infer<typeof ServeOptionsSchema>;
+
+// 2. ERROR CODES
+export const ServeErrorCode = z.enum([
+  'SCREENS_FETCH_FAILED',
+]);
+export type ServeErrorCode = z.infer<typeof ServeErrorCode>;
+
+// 3. RESULT
+export type ServeSuccess = {
+  success: true;
+  projectId: string;
+  projectTitle: string;
+  screens: Array<{ screenId: string; title: string; codeUrl: string }>;
+};
+
+export type ServeFailure = {
+  success: false;
+  error: {
+    code: ServeErrorCode;
+    message: string;
+    recoverable: boolean;
+  };
+};
+
+export type ServeResult = ServeSuccess | ServeFailure;
+
+// 4. INTERFACE
+export interface ServeSpec {
+  execute(projectId: string): Promise<ServeResult>;
+}


### PR DESCRIPTION
Add -l/--list-screens and --json flags to the serve command so agents can discover screens and start the server non-interactively.

- --list-screens (-l): outputs JSON of all screens with deterministic /screens/<screenId> paths, without starting a server
- --json: starts the Vite server in non-interactive mode, outputs JSON with the base URL and per-screen URLs once ready, then keeps running
- Formalized spec.ts with typed ServeErrorCode enum and ServeSpec interface; handler.ts updated to implement it