### PR TITLE
fix: replace mock.module with constructor injection

### DIFF
--- a/src/commands/serve/json-server/handler.test.ts
+++ b/src/commands/serve/json-server/handler.test.ts
@@ -13,16 +13,17 @@ mock.module('../../../lib/server/vite/StitchViteServer.js', () => ({
   },
 }));
 
-mock.module('../../../ui/copy-behaviors/clipboard.js', () => ({
-  downloadText: mock((url: string) => Promise.resolve(`<html>content for ${url}</html>`)),
-}));
-
 const { JsonServerHandler } = await import('./handler.js');
 
 const PROJECT_ID = 'proj_abc';
+const mockDownloadHtml = mock((url: string) => Promise.resolve(`<html>content for ${url}</html>`));
 
 function makeClient(screens: any[]) {
   return createMockStitch(createMockProject(PROJECT_ID, screens));
+}
+
+function makeHandler(client: any) {
+  return new JsonServerHandler(client, mockDownloadHtml);
 }
 
 describe('JsonServerHandler', () => {
@@ -30,6 +31,7 @@ describe('JsonServerHandler', () => {
     mockStart.mockClear();
     mockMount.mockClear();
     mockStop.mockClear();
+    mockDownloadHtml.mockClear();
   });
 
   it('returns ready result with url and screen urls', async () => {
@@ -37,8 +39,7 @@ describe('JsonServerHandler', () => {
       createMockScreen({ screenId: 'scr_1', title: 'Home', getHtml: mock(() => Promise.resolve('https://cdn.example.com/home.html')) }),
     ]);
 
-    const handler = new JsonServerHandler(client);
-    const result = await handler.execute({ projectId: PROJECT_ID });
+    const result = await makeHandler(client).execute({ projectId: PROJECT_ID });
 
     expect(result.success).toBe(true);
     if (!result.success) return;
@@ -57,8 +58,7 @@ describe('JsonServerHandler', () => {
       createMockScreen({ screenId: 'scr_1', title: 'Home', getHtml: mock(() => Promise.resolve('https://cdn.example.com/home.html')) }),
     ]);
 
-    const handler = new JsonServerHandler(client);
-    const result = await handler.execute({ projectId: PROJECT_ID });
+    const result = await makeHandler(client).execute({ projectId: PROJECT_ID });
 
     expect(result.success).toBe(false);
     if (result.success) return;
@@ -72,8 +72,7 @@ describe('JsonServerHandler', () => {
       data: null,
     }));
 
-    const handler = new JsonServerHandler(client);
-    const result = await handler.execute({ projectId: PROJECT_ID });
+    const result = await makeHandler(client).execute({ projectId: PROJECT_ID });
 
     expect(result.success).toBe(false);
     if (result.success) return;

--- a/src/commands/serve/json-server/handler.ts
+++ b/src/commands/serve/json-server/handler.ts
@@ -5,7 +5,10 @@ import { downloadText } from '../../../ui/copy-behaviors/clipboard.js';
 import type { JsonServerSpec, JsonServerInput, JsonServerResult } from './spec.js';
 
 export class JsonServerHandler implements JsonServerSpec {
-  constructor(private readonly client: Stitch) {}
+  constructor(
+    private readonly client: Stitch,
+    private readonly downloadHtml: (url: string) => Promise<string> = downloadText,
+  ) {}
 
   async execute(input: JsonServerInput): Promise<JsonServerResult> {
     let sdkScreens: any[];
@@ -41,7 +44,7 @@ export class JsonServerHandler implements JsonServerSpec {
         try {
           const codeUrl = await s.getHtml();
           if (codeUrl) {
-            const html = await downloadText(codeUrl);
+            const html = await this.downloadHtml(codeUrl);
             server.mount(`/screens/${s.screenId}`, html);
           }
           screens.push({

--- a/src/commands/site/generate/handler.test.ts
+++ b/src/commands/site/generate/handler.test.ts
@@ -11,12 +11,14 @@ mock.module('../../../lib/services/site/SiteService.js', () => ({
   SiteService: { generateSite: mockGenerateSite },
 }));
 
-mock.module('../utils/fetchWithRetry.js', () => ({
-  fetchWithRetry: mock((url: string) => Promise.resolve(`<html>content for ${url}</html>`)),
-}));
+const mockFetchHtml = mock((url: string) => Promise.resolve(`<html>content for ${url}</html>`));
 
 function makeClient(screens: any[]) {
   return createMockStitch(createMockProject(PROJECT_ID, screens));
+}
+
+function makeHandler(client: any) {
+  return new GenerateHandler(client, mockFetchHtml);
 }
 
 function makeInput(overrides: Partial<GenerateInput> = {}): GenerateInput {
@@ -34,6 +36,7 @@ function makeInput(overrides: Partial<GenerateInput> = {}): GenerateInput {
 describe('GenerateHandler', () => {
   beforeEach(() => {
     mockGenerateSite.mockClear();
+    mockFetchHtml.mockClear();
   });
 
   it('returns success with pages when all screens resolve', async () => {
@@ -42,8 +45,7 @@ describe('GenerateHandler', () => {
       createMockScreen({ screenId: 'scr_2', title: 'About', getHtml: mock(() => Promise.resolve('https://cdn.example.com/about.html')) }),
     ]);
 
-    const handler = new GenerateHandler(client);
-    const result = await handler.execute(makeInput());
+    const result = await makeHandler(client).execute(makeInput());
 
     expect(result.success).toBe(true);
     if (!result.success) return;
@@ -61,8 +63,7 @@ describe('GenerateHandler', () => {
       // scr_2 is missing
     ]);
 
-    const handler = new GenerateHandler(client);
-    const result = await handler.execute(makeInput());
+    const result = await makeHandler(client).execute(makeInput());
 
     expect(result.success).toBe(false);
     if (result.success) return;
@@ -76,8 +77,7 @@ describe('GenerateHandler', () => {
       createMockScreen({ screenId: 'scr_2', title: 'About', getHtml: mock(() => Promise.resolve('https://cdn.example.com/about.html')) }),
     ]);
 
-    const handler = new GenerateHandler(client);
-    const result = await handler.execute(makeInput());
+    const result = await makeHandler(client).execute(makeInput());
 
     expect(result.success).toBe(false);
     if (result.success) return;

--- a/src/commands/site/generate/handler.ts
+++ b/src/commands/site/generate/handler.ts
@@ -6,7 +6,10 @@ import { AssetGateway } from '../../../lib/server/AssetGateway.js';
 import { fetchWithRetry } from '../utils/fetchWithRetry.js';
 
 export class GenerateHandler implements GenerateSpec {
-  constructor(private readonly client: Stitch) {}
+  constructor(
+    private readonly client: Stitch,
+    private readonly fetchHtml: (url: string) => Promise<string> = fetchWithRetry,
+  ) {}
 
   async execute(input: GenerateInput): Promise<GenerateResult> {
     try {
@@ -41,7 +44,7 @@ export class GenerateHandler implements GenerateSpec {
           const screen = screenMap.get(r.screenId)!;
           try {
             const htmlUrl = await screen.getHtml();
-            const html = htmlUrl ? await fetchWithRetry(htmlUrl) : '';
+            const html = htmlUrl ? await this.fetchHtml(htmlUrl) : '';
             htmlContent.set(r.screenId, html);
           } catch (e: any) {
             errors.push(`${r.screenId}: ${e.message}`);


### PR DESCRIPTION
mock.module calls for fetchWithRetry and downloadText were leaking into unrelated virtual tool tests when the full suite ran together. Switching to injected dependencies keeps each handler testable without polluting the shared module registry.