### PR TITLE
feat: add --json flag to doctor and init commands

### DIFF
--- a/src/commands/doctor/command.ts
+++ b/src/commands/doctor/command.ts
@@ -7,6 +7,7 @@ export const command: CommandDefinition<any, DoctorOptions> = {
   description: 'Verify configuration health',
   options: [
     { flags: '--verbose', description: 'Show detailed error information', defaultValue: false },
+    { flags: '--json', description: 'Output results as JSON', defaultValue: false },
   ],
   action: async (_args, options) => {
     try {
@@ -15,6 +16,7 @@ export const command: CommandDefinition<any, DoctorOptions> = {
       const handler = new DoctorHandler();
       const result = await handler.execute({
         verbose: parsedOptions.verbose,
+        json: parsedOptions.json,
       });
 
       if (!result.success) {

--- a/src/commands/doctor/handler.test.ts
+++ b/src/commands/doctor/handler.test.ts
@@ -132,6 +132,45 @@ describe('DoctorHandler', () => {
     });
   });
 
+  describe('json mode', () => {
+    it('outputs only JSON to stdout and no human text when json: true', async () => {
+      process.env.STITCH_API_KEY = 'AIzaSyTestKey123';
+      mockTestConnectionWithApiKey.mockResolvedValue({
+        success: true,
+        data: { connected: true, statusCode: 200, url: 'https://stitch.googleapis.com/mcp' },
+      });
+
+      const mockGcloudService: any = {
+        ensureInstalled: mockEnsureInstalled,
+        authenticate: mockAuthenticate,
+        authenticateADC: mockAuthenticateADC,
+        listProjects: mockListProjects,
+        getProjectId: mockGetProjectId,
+        getAccessToken: mockGetAccessToken,
+      };
+      const mockStitchService: any = {
+        testConnection: mockTestConnection,
+        testConnectionWithApiKey: mockTestConnectionWithApiKey,
+      };
+
+      const logged: string[] = [];
+      const originalLog = console.log;
+      console.log = (...args: any[]) => logged.push(args.map(String).join(' '));
+
+      const handler = new DoctorHandler(mockGcloudService, mockStitchService);
+      const result = await handler.execute({ verbose: false, json: true });
+
+      console.log = originalLog;
+
+      // All console output must be valid JSON
+      expect(logged.length).toBe(1);
+      const parsed = JSON.parse(logged[0]!);
+      expect(parsed.success).toBe(true);
+      expect(parsed.data.allPassed).toBe(true);
+      expect(result.success).toBe(true);
+    });
+  });
+
   describe('API key auth mode', () => {
     it('should pass all checks when API key is set and connectivity passes', async () => {
       process.env.STITCH_API_KEY = 'AIzaSyTestKey123';

--- a/src/commands/doctor/handler.ts
+++ b/src/commands/doctor/handler.ts
@@ -55,27 +55,41 @@ export class DoctorHandler implements DoctorCommand {
       checks: []
     };
 
-    console.log(`\n${theme.blue('Stitch Doctor')}\n`);
+    if (!input.json) console.log(`\n${theme.blue('Stitch Doctor')}\n`);
 
     try {
       let spinner: ReturnType<typeof createSpinner>;
       await runSteps(this.steps, context, {
         onBeforeStep: (step) => {
+          if (input.json) return;
           spinner = createSpinner();
           spinner.start(step.name);
         },
         onAfterStep: (_step, result) => {
-          if (result.success) {
-            spinner.succeed(result.detail || 'Passed');
-          } else {
-            spinner.fail(result.error?.message || 'Failed');
+          if (!input.json) {
+            if (result.success) {
+              spinner.succeed(result.detail || 'Passed');
+            } else {
+              spinner.fail(result.error?.message || 'Failed');
+            }
           }
           return false; // always continue
         },
       });
 
-      // Summary
       const allPassed = context.checks.every((c) => c.passed);
+
+      const result = {
+        success: true as const,
+        data: { checks: context.checks, allPassed },
+      };
+
+      if (input.json) {
+        console.log(JSON.stringify(result, null, 2));
+        return result;
+      }
+
+      // Human output
       console.log(`\n${theme.blue('─'.repeat(60))}\n`);
       console.log(theme.blue('Health Check Summary\n'));
 
@@ -87,7 +101,6 @@ export class DoctorHandler implements DoctorCommand {
         }
       }
 
-      // Show full error details for failed checks if verbose is enabled
       if (input.verbose) {
         const failedChecksWithDetails = context.checks.filter(c => !c.passed && c.details);
         if (failedChecksWithDetails.length > 0) {
@@ -104,13 +117,7 @@ export class DoctorHandler implements DoctorCommand {
         `\n${allPassed ? theme.green('All checks passed!') : theme.yellow('Some checks failed')}\n`
       );
 
-      return {
-        success: true,
-        data: {
-          checks: context.checks,
-          allPassed,
-        },
-      };
+      return result;
 
     } catch (error) {
       return {

--- a/src/commands/doctor/spec.test.ts
+++ b/src/commands/doctor/spec.test.ts
@@ -22,6 +22,14 @@ describe('DoctorCommand', () => {
 
 
 
+    it('should default json to false', () => {
+      const result = DoctorInputSchema.safeParse({});
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.json).toBe(false);
+      }
+    });
+
     it('should fail with invalid input type for verbose', () => {
       const input = {
         verbose: 'true',

--- a/src/commands/doctor/spec.ts
+++ b/src/commands/doctor/spec.ts
@@ -6,11 +6,13 @@ import { z } from 'zod';
 
 export const DoctorOptionsSchema = z.object({
   verbose: z.boolean().default(false),
+  json: z.boolean().default(false),
 });
 export type DoctorOptions = z.infer<typeof DoctorOptionsSchema>;
 
 export const DoctorInputSchema = z.object({
   verbose: z.boolean().default(false),
+  json: z.boolean().default(false),
 });
 export type DoctorInput = z.infer<typeof DoctorInputSchema>;
 

--- a/src/commands/init/command.ts
+++ b/src/commands/init/command.ts
@@ -11,6 +11,7 @@ export const command: CommandDefinition<any, InitOptions> = {
     { flags: '--defaults', description: 'Use default values for prompts', defaultValue: false },
     { flags: '-c, --client <client>', description: 'MCP client to configure' },
     { flags: '-t, --transport <transport>', description: 'Transport type (http or stdio)' },
+    { flags: '--json', description: 'Output result as JSON', defaultValue: false },
   ],
   action: async (_args, options) => {
     try {
@@ -23,12 +24,17 @@ export const command: CommandDefinition<any, InitOptions> = {
         autoVerify: parsedOptions.yes,
         client: parsedOptions.client,
         transport: parsedOptions.transport,
+        json: parsedOptions.json,
       });
 
       if (!result.success) {
-        console.error(theme.red(`\n${icons.error} Setup failed: ${result.error.message}`));
-        if (result.error.suggestion) {
-          console.error(theme.gray(`  ${result.error.suggestion}`));
+        if (parsedOptions.json) {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          console.error(theme.red(`\n${icons.error} Setup failed: ${result.error.message}`));
+          if (result.error.suggestion) {
+            console.error(theme.gray(`  ${result.error.suggestion}`));
+          }
         }
         process.exit(1);
       }

--- a/src/commands/init/handler.test.ts
+++ b/src/commands/init/handler.test.ts
@@ -140,6 +140,52 @@ describe('InitHandler', () => {
     expect(mockStitchService.enableAPI).not.toHaveBeenCalled();
   });
 
+  test('when json: true, outputs only JSON and no human text', async () => {
+    const mockGcloudService: any = {
+      ensureInstalled: mock(() => Promise.resolve({
+        success: true,
+        data: { location: 'system', version: '450.0.0', path: '/usr/bin/gcloud' }
+      })),
+      setProject: mock(() => Promise.resolve({ success: true, data: { projectId: 'test-project' } })),
+      installBetaComponents: mock(() => Promise.resolve({ success: true })),
+      getAccessToken: mock(() => Promise.resolve('test-token')),
+      getActiveAccount: mock(() => Promise.resolve('test@example.com')),
+      hasADC: mock(() => Promise.resolve(true)),
+      getProjectId: mock(() => Promise.resolve(null)),
+    };
+    const mockProjectService: any = {
+      selectProject: mock(() => Promise.resolve({ success: true, data: { projectId: 'test-project', name: 'Test Project' } })),
+      getProjectDetails: mock(() => Promise.resolve({ success: true, data: { projectId: 'test-project', name: 'Test Project' } })),
+    };
+    const mockStitchService: any = {
+      configureIAM: mock(() => Promise.resolve({ success: true, data: { role: 'roles/serviceusage.serviceUsageConsumer' } })),
+      enableAPI: mock(() => Promise.resolve({ success: true, data: { api: 'stitch.googleapis.com' } })),
+      testConnection: mock(() => Promise.resolve({ success: true, data: { statusCode: 200, url: 'https://stitch.googleapis.com/mcp' } })),
+      checkIAMRole: mock(() => Promise.resolve(true)),
+      checkAPIEnabled: mock(() => Promise.resolve(true)),
+    };
+    const mockMcpConfigService: any = {
+      generateConfig: mock(() => Promise.resolve({
+        success: true,
+        data: { config: '{ "mcp": "config" }', instructions: 'Instructions' }
+      })),
+    };
+
+    const logged: string[] = [];
+    const originalLog = console.log;
+    console.log = (...args: any[]) => logged.push(args.map(String).join(' '));
+
+    const handler = new InitHandler(mockGcloudService, mockMcpConfigService, mockProjectService, mockStitchService);
+    await handler.execute({ local: false, defaults: false, autoVerify: true, json: true });
+
+    console.log = originalLog;
+
+    expect(logged.length).toBe(1);
+    const parsed = JSON.parse(logged[0]!);
+    expect(parsed.success).toBe(true);
+    expect(parsed.data.projectId).toBe('test-project');
+  });
+
   test('should fail if no authenticated account after checklist', async () => {
     const mockGcloudService: any = {
       ensureInstalled: mock(() => Promise.resolve({

--- a/src/commands/init/handler.ts
+++ b/src/commands/init/handler.ts
@@ -71,7 +71,7 @@ export class InitHandler implements InitCommand {
       animationDelayMs: 100,
     });
 
-    console.log(`\n${theme.blue('🧵 Stitch MCP Setup')}\n`);
+    if (!input.json) console.log(`\n${theme.blue('🧵 Stitch MCP Setup')}\n`);
 
     const context: InitContext = {
       input,
@@ -84,18 +84,18 @@ export class InitHandler implements InitCommand {
 
     try {
       const { stoppedAt } = await runSteps(this.steps, context, {
-        onBeforeStep: (step) => this.updateStep(step.id, 'IN_PROGRESS'),
+        onBeforeStep: (step) => { if (!input.json) this.updateStep(step.id, 'IN_PROGRESS'); },
         onAfterStep: (step, result) => {
           if (!result.success) {
             const message = result.error?.message || result.detail || 'Failed';
-            this.updateStep(step.id, 'FAILED', message);
+            if (!input.json) this.updateStep(step.id, 'FAILED', message);
             return true; // stop on failure
           }
           const status = (result.status as ChecklistItemStateType) || 'COMPLETE';
-          this.updateStep(step.id, status, result.detail, result.reason);
+          if (!input.json) this.updateStep(step.id, status, result.detail, result.reason);
           return false;
         },
-        onSkippedStep: (step) => this.updateStep(step.id, 'SKIPPED', 'Not required'),
+        onSkippedStep: (step) => { if (!input.json) this.updateStep(step.id, 'SKIPPED', 'Not required'); },
       });
 
       if (stoppedAt) {
@@ -110,7 +110,21 @@ export class InitHandler implements InitCommand {
         };
       }
 
-      // Final Summary
+      const result = {
+        success: true as const,
+        data: {
+          projectId: context.projectId || 'ignored',
+          mcpConfig: context.finalConfig || '',
+          instructions: context.instructions || '',
+        },
+      };
+
+      if (input.json) {
+        console.log(JSON.stringify(result, null, 2));
+        return result;
+      }
+
+      // Human output
       const { percent } = this.checklist.getProgress();
       const barWidth = 40;
       const filled = Math.round((percent / 100) * barWidth);
@@ -122,17 +136,10 @@ export class InitHandler implements InitCommand {
       }
 
       if (context.instructions) {
-          console.log(context.instructions);
+        console.log(context.instructions);
       }
 
-      return {
-        success: true,
-        data: {
-          projectId: context.projectId || 'ignored',
-          mcpConfig: context.finalConfig || '',
-          instructions: context.instructions || '',
-        },
-      };
+      return result;
 
     } catch (error) {
       return {

--- a/src/commands/init/spec.test.ts
+++ b/src/commands/init/spec.test.ts
@@ -1,10 +1,28 @@
-import { describe, test, expect } from 'bun:test';
+import { describe, test, it, expect } from 'bun:test';
 import { InitHandler } from './handler';
-import { InitCommand } from './spec';
+import { InitCommand, InitInputSchema } from './spec';
 
 describe('InitCommand', () => {
   test('should be implemented by InitHandler', () => {
     const handler: InitCommand = new InitHandler();
     expect(handler).toBeInstanceOf(InitHandler);
+  });
+});
+
+describe('InitInputSchema', () => {
+  it('defaults json to false', () => {
+    const result = InitInputSchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.json).toBe(false);
+    }
+  });
+
+  it('accepts json: true', () => {
+    const result = InitInputSchema.safeParse({ json: true });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.json).toBe(true);
+    }
   });
 });

--- a/src/commands/init/spec.ts
+++ b/src/commands/init/spec.ts
@@ -10,6 +10,7 @@ export const InitOptionsSchema = z.object({
   defaults: z.boolean().default(false),
   client: z.string().optional(),
   transport: z.string().optional(),
+  json: z.boolean().default(false),
 });
 export type InitOptions = z.infer<typeof InitOptionsSchema>;
 
@@ -19,6 +20,7 @@ export const InitInputSchema = z.object({
   autoVerify: z.boolean().default(false),
   client: z.string().optional(),
   transport: z.string().optional(),
+  json: z.boolean().default(false),
 });
 export type InitInput = z.infer<typeof InitInputSchema>;
 


### PR DESCRIPTION
Agents can now get structured JSON output from both commands instead of human-readable TUI text.

- doctor --json: suppresses spinners and summary, outputs { success, data: { allPassed, checks } } — useful for pre-flight environment checks
- init --json: suppresses checklist and progress bar, outputs { success, data: { projectId, mcpConfig, instructions } } — enables fully headless setup with --defaults --yes -c <client> -t <transport> --json