### PR TITLE
fix: prevent proxy from exiting before handling MCP requests

### DIFF
--- a/src/commands/proxy/command.ts
+++ b/src/commands/proxy/command.ts
@@ -25,7 +25,8 @@ export const command: CommandDefinition<any, ProxyOptions> = {
         console.error(theme.red(`\n${icons.error} Proxy server error: ${result.error?.message}`));
         process.exit(1);
       }
-      process.exit(0);
+      // No process.exit(0) here — the proxy is a long-running server.
+      // The stdin listener keeps the event loop alive until the client disconnects.
     } catch (error) {
       console.error(theme.red(`\n${icons.error} Unexpected error:`), error);
       process.exit(1);

--- a/src/commands/proxy/handler.test.ts
+++ b/src/commands/proxy/handler.test.ts
@@ -28,17 +28,25 @@ describe('ProxyCommandHandler (SDK)', () => {
     const result = await handler.execute({});
 
     expect(result.success).toBe(true);
+    expect(result.data?.status).toBe('running');
     expect(startSpy).toHaveBeenCalledTimes(1);
-    // First arg to start() should be a StdioServerTransport instance
     expect(startSpy.mock.calls[0][0]).toBeInstanceOf(StdioServerTransport);
   });
 
   it('passes STITCH_API_KEY env var to StitchProxy', async () => {
     process.env.STITCH_API_KEY = 'test-key';
-    const handler = new ProxyCommandHandler();
+    let receivedApiKey: string | undefined;
+
+    const handler = new ProxyCommandHandler({
+      createProxy: (opts) => {
+        receivedApiKey = opts.apiKey;
+        return { start: async () => {}, close: async () => {} } as any;
+      },
+    });
+
     const result = await handler.execute({});
-    // Proxy reads from env — confirm it doesn't throw when key is set
     expect(result.success).toBe(true);
+    expect(receivedApiKey).toBe('test-key');
   });
 
   it('returns error when proxy start fails', async () => {

--- a/src/commands/proxy/handler.ts
+++ b/src/commands/proxy/handler.ts
@@ -32,7 +32,7 @@ export class ProxyCommandHandler {
       });
       const transport = this.createTransport();
       await proxy.start(transport);
-      return { success: true, data: { status: 'stopped' } };
+      return { success: true, data: { status: 'running' } };
     } catch (e: any) {
       return { success: false, error: { code: 'PROXY_START_ERROR', message: e.message, recoverable: false } };
     }


### PR DESCRIPTION
- Remove `process.exit(0)` from the proxy command action - the proxy is a long-running stdio server, not a run-and-exit command
- The `StdioServerTransport`'s stdin listener naturally keeps the Node.js event loop alive until the client disconnects

### Root Cause

When the proxy was migrated from the custom `ProxyHandler` to the SDK's `StitchProxy` (#136), the keep-alive mechanism was lost. `StitchProxy.start()` returns immediately after connecting to Stitch, and the command action then called `process.exit(0)`, killing the server ~2 seconds after startup - before it could handle any MCP client messages.

### Test plan

- [x] `bun test` - 460 pass, 0 fail
- [x] Integration test: proxy stays alive, responds to `initialize` and `tools/list`
- [x] End-to-end: configured as Claude Code MCP server, successfully called `list_projects` through the proxy

Fixes #147