### PR TITLE
fix: proxy exits immediately — process never handles MCP stdio messages

### DIFF
--- a/src/commands/proxy/handler.ts
+++ b/src/commands/proxy/handler.ts
@@ -32,6 +32,7 @@ export class ProxyCommandHandler {
       });
       const transport = this.createTransport();
       await proxy.start(transport);
+      await new Promise(() => {});
       return { success: true, data: { status: 'running' } };
     } catch (e: any) {
       return { success: false, error: { code: 'PROXY_START_ERROR', message: e.message, recoverable: false } };


### PR DESCRIPTION
## Problem

The `proxy` command connects to `stitch.googleapis.com` successfully but the Node.js process exits immediately after `proxy.start(transport)` returns. The stdio MCP transport never gets to handle any messages, breaking integration with Claude Code and other MCP clients.

In `src/commands/proxy/handler.ts`, `execute()` calls `await proxy.start(transport)` then returns `{ success: true }`. The command framework receives the return value and the process exits — the stdio server is killed before it can respond to the MCP `initialize` handshake.

## Fix

Add `await new Promise(() => {});` after `proxy.start(transport)` to keep the event loop alive indefinitely, allowing the stdio transport to process MCP messages until the parent process terminates the child.

## Verification

Before fix — proxy connects but never responds to MCP initialize:
```
$ echo '{"jsonrpc":"2.0","id":0,"method":"initialize",...}' | stitch-mcp proxy
[stitch-proxy] Connected to Stitch, discovered 12 tools
[stitch-proxy] Proxy server running
# stdout: 0 bytes — no response
```

After fix — proxy responds correctly:
```
$ echo '{"jsonrpc":"2.0","id":0,"method":"initialize",...}' | stitch-mcp proxy
[stitch-proxy] Connected to Stitch, discovered 12 tools
[stitch-proxy] Proxy server running
{"result":{"protocolVersion":"2024-11-05","capabilities":{"tools":{}},"serverInfo":{"name":"stitch-proxy","version":"1.0.0"}},"jsonrpc":"2.0","id":0}
```

## Related Issues

Fixes #153, fixes #154, fixes #155, fixes #161, fixes #165