### PR TITLE
feat(proxy): support ADC/OAuth2 auth when no API key is set

### DIFF
--- a/src/commands/proxy/command.ts
+++ b/src/commands/proxy/command.ts
@@ -14,7 +14,10 @@ export const command: CommandDefinition<any, ProxyOptions> = {
     try {
       const parsedOptions = ProxyOptionsSchema.parse(options);
       const { ProxyCommandHandler } = await import('./handler.js');
-      const handler = new ProxyCommandHandler();
+      const { GcloudHandler } = await import('../../services/gcloud/handler.js');
+      const handler = new ProxyCommandHandler({
+        gcloudService: new GcloudHandler(),
+      });
 
       const result = await handler.execute({
         port: parsedOptions.port,

--- a/src/commands/proxy/handler.ts
+++ b/src/commands/proxy/handler.ts
@@ -1,6 +1,7 @@
 import { StitchProxy } from '@google/stitch-sdk';
 import type { StitchProxy as StitchProxyType } from '@google/stitch-sdk';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import type { GcloudService } from '../../services/gcloud/spec.js';
 
 interface ProxyCommandInput {
   port?: number;
@@ -14,21 +15,38 @@ interface ProxyCommandResult {
 }
 
 export class ProxyCommandHandler {
-  private createProxy: (opts: { apiKey?: string }) => StitchProxyType;
+  private createProxy: (opts: { apiKey?: string; accessToken?: string }) => StitchProxyType;
   private createTransport: () => StdioServerTransport;
+  private gcloudService?: GcloudService;
 
   constructor(deps?: {
-    createProxy?: (opts: { apiKey?: string }) => StitchProxyType;
+    createProxy?: (opts: { apiKey?: string; accessToken?: string }) => StitchProxyType;
     createTransport?: () => StdioServerTransport;
+    gcloudService?: GcloudService;
   }) {
     this.createProxy = deps?.createProxy ?? ((opts) => new StitchProxy(opts));
     this.createTransport = deps?.createTransport ?? (() => new StdioServerTransport());
+    this.gcloudService = deps?.gcloudService;
   }
 
   async execute(input: ProxyCommandInput): Promise<ProxyCommandResult> {
     try {
+      const apiKey = process.env.STITCH_API_KEY;
+      let accessToken: string | undefined;
+
+      // When no API key is set, try to get an access token via ADC / gcloud
+      if (!apiKey && this.gcloudService) {
+        // Ensure gcloud is discovered before attempting token fetch
+        await this.gcloudService.ensureInstalled({ useSystemGcloud: !!process.env.STITCH_USE_SYSTEM_GCLOUD });
+        const token = await this.gcloudService.getAccessToken();
+        if (token) {
+          accessToken = token;
+        }
+      }
+
       const proxy = this.createProxy({
-        apiKey: process.env.STITCH_API_KEY,
+        apiKey,
+        accessToken,
       });
       const transport = this.createTransport();
       await proxy.start(transport);


### PR DESCRIPTION
## Summary
- Wire `gcloudService.getAccessToken()` into the proxy handler so that when `STITCH_API_KEY` is not set, the proxy falls back to Application Default Credentials
- Enables `STITCH_USE_SYSTEM_GCLOUD` workflows, especially on Windows where system gcloud integration is needed
- Depends on google-labs-code/stitch-sdk#314 for `accessToken` support in the SDK proxy module — **MERGED** ✅ (shipping in next SDK release after v0.1.0)

## Problem
The proxy handler only passes `apiKey` to `StitchProxy`. The `STITCH_USE_SYSTEM_GCLOUD` env var is used in the auth service but never wired into the proxy handler. Additionally, the SDK's proxy module itself only supported API key auth — it hardcoded `X-Goog-Api-Key` headers and had no `accessToken` field. That has been fixed upstream in SDK #314.

## Changes

### Source (`src/commands/proxy/`)
- **handler.ts**: Accept optional `GcloudService` dep; when no `STITCH_API_KEY` is set, call `ensureInstalled()` then `getAccessToken()` and pass the token to `StitchProxy`
- **command.ts**: Instantiate `GcloudHandler` and pass it to `ProxyCommandHandler`

## Test plan
- [x] Verified proxy connects to Stitch via ADC with `STITCH_USE_SYSTEM_GCLOUD=true` and no `STITCH_API_KEY` — discovered 12 tools
- [x] Verified proxy works with `STITCH_ACCESS_TOKEN` env var (direct token)
- [x] Verified proxy works with OAuth user token (`gcloud auth print-access-token`)
- [x] Type-checks clean (`npx tsc --noEmit` — zero errors in changed files)
- [x] Existing tests still pass (485 pass, 6 skip, 0 fail)
- [x] Test with API key auth to confirm no regression — discovered 12 tools