### PR TITLE
fix: cross-runtime compat and bump stitch-sdk to 0.3.5

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@_davideast/stitch-mcp",
       "dependencies": {
         "@astrojs/compiler": "^2.13.1",
-        "@google/stitch-sdk": "0.3.4",
+        "@google/stitch-sdk": "0.3.5",
         "@inquirer/prompts": "^8.2.0",
         "@modelcontextprotocol/sdk": "^1.25.2",
         "adm-zip": "^0.5.16",
@@ -134,7 +134,7 @@
 
     "@exodus/bytes": ["@exodus/bytes@1.15.0", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ=="],
 
-    "@google/stitch-sdk": ["@google/stitch-sdk@0.3.4", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.23.0", "cheerio": "^1.0.0-rc.12", "zod": "^4.3.5" } }, "sha512-jrm0F1lggZrmeZT7bbm3wf8pi1XDIFrupP3hWF+b4OVw7a68LnA7HNL5+S6cMcFuRgc//klszX5I172UzCfJhQ=="],
+    "@google/stitch-sdk": ["@google/stitch-sdk@0.3.5", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.23.0", "cheerio": "^1.0.0-rc.12", "zod": "^4.3.5" } }, "sha512-81Jow7WvDP93gHVEP327LJjE0neXGnuv43RmfVgPUjzOGN6rxrCMBwX53UgrpkDOkZt9yr7K8gGOpxbuOdIe5A=="],
 
     "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.9.0", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.9.0" } }, "sha512-lBW6/m5BIFl3pMuWPNN0lIOYw9LMCmPfix53ExS3FBi4E+NELEljQ3xH6aAV9IYiQRfn9YIIgzzMrD0vIcD7tw=="],
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@astrojs/compiler": "^2.13.1",
-    "@google/stitch-sdk": "0.3.4",
+    "@google/stitch-sdk": "0.3.5",
     "@inquirer/prompts": "^8.2.0",
     "@modelcontextprotocol/sdk": "^1.25.2",
     "adm-zip": "^0.5.16",

--- a/src/commands/tool/steps/ParseArgsStep.ts
+++ b/src/commands/tool/steps/ParseArgsStep.ts
@@ -1,3 +1,4 @@
+import { readFile } from 'node:fs/promises';
 import type { CommandStep, StepResult } from '../../../framework/CommandStep.js';
 import type { ToolContext } from '../context.js';
 
@@ -17,7 +18,7 @@ export class ParseArgsStep implements CommandStep<ToolContext> {
     if (context.input.data) {
       args = JSON.parse(context.input.data);
     } else if (context.input.dataFile) {
-      const content = await Bun.file(context.input.dataFile.replace('@', '')).text();
+      const content = await readFile(context.input.dataFile.replace('@', ''), 'utf-8');
       args = JSON.parse(content);
     }
 

--- a/tests/commands/tool/steps/ParseArgsStep.test.ts
+++ b/tests/commands/tool/steps/ParseArgsStep.test.ts
@@ -1,6 +1,12 @@
-import { describe, it, expect, mock, beforeEach, spyOn } from "bun:test";
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { ParseArgsStep } from "../../../../src/commands/tool/steps/ParseArgsStep.js";
 import type { ToolContext } from "../../../../src/commands/tool/context.js";
+
+const tmpDir = mkdtempSync(join(tmpdir(), "parse-args-test-"));
+afterAll(() => rmSync(tmpDir, { recursive: true, force: true }));
 
 describe("ParseArgsStep", () => {
   let step: ParseArgsStep;
@@ -44,14 +50,13 @@ describe("ParseArgsStep", () => {
     });
 
     it("should parse JSON data from @file", async () => {
-      const mockFileText = mock(() => Promise.resolve('{"title": "From File"}'));
-      spyOn(Bun, "file").mockReturnValue({ text: mockFileText } as any);
+      const filePath = join(tmpDir, "data.json");
+      writeFileSync(filePath, '{"title": "From File"}', "utf-8");
 
-      const context = makeContext({ toolName: "create_project", dataFile: "@data.json" });
+      const context = makeContext({ toolName: "create_project", dataFile: `@${filePath}` });
       await step.run(context);
 
       expect(context.parsedArgs).toEqual({ title: "From File" });
-      expect(Bun.file).toHaveBeenCalledWith("data.json");
     });
 
     it("should default to empty args when no data provided", async () => {


### PR DESCRIPTION
## Fixes

### 1. `Bun is not defined` when running via `bun x` / `npx`

`ParseArgsStep.ts` used `Bun.file()` to read the `-f` argument file. The `Bun` global is not available when the CLI is invoked via `bun x` or `npx`. Replaced with `readFile()` from `node:fs/promises` which works in both runtimes.

### 2. `MissingRefError: can't resolve reference #/$defs/ScreenInstance`

Bumps `@google/stitch-sdk` from `0.3.4` to `0.3.5`, which repairs tool schemas before AJV compilation can trigger a crash. See [google-labs-code/stitch-sdk#355](https://github.com/google-labs-code/stitch-sdk/pull/355).

## Changes

| File | Change |
|---|---|
| `src/commands/tool/steps/ParseArgsStep.ts` | `Bun.file()` → `readFile()` from `node:fs/promises` |
| `package.json` | `@google/stitch-sdk` `0.3.4` → `0.3.5` |
| `bun.lock` | Updated lockfile |